### PR TITLE
types: Accept string for `I18nextToolkitConfig.indentation`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -85,7 +85,7 @@ export interface I18nextToolkitConfig {
     sort?: boolean;
 
     /** Number of spaces for JSON indentation (default: 2) */
-    indentation?: number;
+    indentation?: number | string;
 
     /** Default value to use for missing translations in secondary languages */
     defaultValue?: string;

--- a/src/utils/file-utils.ts
+++ b/src/utils/file-utils.ts
@@ -114,7 +114,7 @@ export async function loadTranslationFile (filePath: string): Promise<Record<str
 export function serializeTranslationFile (
   data: Record<string, any>,
   format: I18nextToolkitConfig['extract']['outputFormat'] = 'json',
-  indentation: number = 2
+  indentation: number | string = 2
 ): string {
   const jsonString = JSON.stringify(data, null, indentation)
 


### PR DESCRIPTION
`JSON.stringify` already accepts a string here, and it’s useful to be able to pass `"\t"`.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)