### PR TITLE
Make sort comparator customizable

### DIFF
--- a/src/extractor/core/translation-manager.ts
+++ b/src/extractor/core/translation-manager.ts
@@ -97,7 +97,11 @@ export async function getTranslations (
         }
       }
 
-      const sortedKeys = (config.extract.sort === false) ? nsKeys : [...nsKeys].sort((a, b) => a.key.localeCompare(b.key))
+      const sortedKeys = config.extract.sort === false
+        ? nsKeys
+        : [...nsKeys].sort(typeof config.extract.sort === 'function'
+            ? config.extract.sort
+            : (a, b) => a.key.localeCompare(b.key))
       for (const { key, defaultValue } of sortedKeys) {
         const existingValue = getNestedValue(existingTranslations, key, keySeparator)
         const valueToSet = existingValue ?? (locale === primaryLanguage ? defaultValue : (config.extract.defaultValue ?? ''))

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,8 +81,8 @@ export interface I18nextToolkitConfig {
     /** Glob patterns for keys to preserve even if not found in source (for dynamic keys) */
     preservePatterns?: string[];
 
-    /** Whether to sort keys alphabetically in output files (default: true) */
-    sort?: boolean;
+    /** Whether to sort keys alphabetically in output files, or a comparator function to customize the order (default: true) */
+    sort?: boolean | ((a: ExtractedKey, b: ExtractedKey) => number);
 
     /** Number of spaces for JSON indentation (default: 2) */
     indentation?: number;

--- a/test/extractor.getTranslations.test.ts
+++ b/test/extractor.getTranslations.test.ts
@@ -93,4 +93,29 @@ describe('extractor.getTranslations', () => {
     expect(resultKeys[0]).toBe('zebra')
     expect(resultKeys[1]).toBe('apple')
   })
+
+  it('should use custom sort comparator', async () => {
+    const keysMap = new Map<string, { key: string; defaultValue?: string }>()
+    // Add keys in a specific, non-alphabetical order
+    keysMap.set('zebra', { key: 'zebra', defaultValue: 'Zebra' })
+    keysMap.set('apple', { key: 'apple', defaultValue: 'Apple' })
+    keysMap.set('snail', { key: 'snail', defaultValue: 'Snail' })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: 'src/**/*.{ts,tsx}',
+        output: 'locales/{{language}}/{{namespace}}.json',
+        sort: (a, b) => a.key > b.key ? -1 : a.key < b.key ? 1 : 0, // sort in reverse order
+      }
+    }
+
+    const [result] = await getTranslations(keysMap as any, new Set(), config)
+
+    // Assert that the object keys are ordered by the custom comparator
+    const resultKeys = Object.keys(result.newTranslations)
+    expect(resultKeys[0]).toBe('zebra')
+    expect(resultKeys[1]).toBe('snail')
+    expect(resultKeys[2]).toBe('apple')
+  })
 })


### PR DESCRIPTION
This is useful, for example, for migrating from i18next-scanner (which uses non-locale-aware sorting) without unnecessarily expanding the diff. i18next-parser supports this customization as well.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)