### PR TITLE
namespace prefix should override scope ns value

### DIFF
--- a/src/extractor/parsers/ast-visitors.ts
+++ b/src/extractor/parsers/ast-visitors.ts
@@ -454,12 +454,12 @@ export class ASTVisitors {
       let key = keysToProcess[i]
       let ns: string | undefined
 
-      // Determine namespace (explicit ns > scope ns > ns:key > default)
+      // Determine namespace (explicit ns > ns:key > scope ns > default)
+      // See https://www.i18next.com/overview/api#getfixedt
       if (options) {
         const nsVal = getObjectPropValue(options, 'ns')
         if (typeof nsVal === 'string') ns = nsVal
       }
-      if (!ns && scopeInfo?.defaultNs) ns = scopeInfo.defaultNs
 
       const nsSeparator = this.config.extract.nsSeparator ?? ':'
       if (!ns && nsSeparator && key.includes(nsSeparator)) {
@@ -467,6 +467,8 @@ export class ASTVisitors {
         ns = parts.shift()
         key = parts.join(nsSeparator)
       }
+
+      if (!ns && scopeInfo?.defaultNs) ns = scopeInfo.defaultNs
       if (!ns) ns = this.config.extract.defaultNS
 
       let finalKey = key

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -141,6 +141,20 @@ describe('extractor: advanced t features', () => {
       expect(headerFile!.newTranslations).toEqual({ title: 'A Header' })
     })
 
+    it('should allow key to override the useTranslation namespace', async () => {
+      const sampleCode = `
+        const { t } = useTranslation('common');
+        t('header:title', { defaultValue: 'A Header' });
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const headerFile = results.find(r => r.path.endsWith('/locales/en/header.json'))
+
+      expect(headerFile).toBeDefined()
+      expect(headerFile!.newTranslations).toEqual({ title: 'A Header' })
+    })
+
     it('should detect the correct namespace from multiple useTranslation calls', async () => {
       const sampleCode = `
         function NotificationItem() {


### PR DESCRIPTION
Align the ns overrides with i18next behavior.

Fixes #32

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)