### PR TITLE
support combining context with plural keys

### DIFF
--- a/src/extractor/parsers/ast-utils.ts
+++ b/src/extractor/parsers/ast-utils.ts
@@ -15,15 +15,16 @@ import type { ObjectExpression } from '@swc/core'
  * @param propName - The property name to locate
  * @returns The matching KeyValueProperty node if found, otherwise undefined.
  */
-export function getObjectProperty (object: ObjectExpression, propName: string): any {
-  return (object.properties).find(
-    (p) =>
-      p.type === 'KeyValueProperty' &&
-      (
-        (p.key?.type === 'Identifier' && p.key.value === propName) ||
-        (p.key?.type === 'StringLiteral' && p.key.value === propName)
-      )
-  )
+export function getObjectProperty (object: ObjectExpression, propName: string) {
+  return (object.properties).filter(
+    (p) => p.type === 'KeyValueProperty')
+    .find(
+      (p) =>
+        (
+          (p.key?.type === 'Identifier' && p.key.value === propName) ||
+          (p.key?.type === 'StringLiteral' && p.key.value === propName)
+        )
+    )
 }
 
 /**

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -687,6 +687,32 @@ describe('extractor: advanced t features', () => {
         place_ordinal_other: '{{count}}th place',
       })
     })
+
+    it('should combine context and plural variants', async () => {
+      const sampleCode = `
+        const test = true;
+
+        t('state', {
+          context: test ? 'test' : 'production', 
+          count: 2,
+          defaultValue_one: "{{count}} car",
+          defaultValue_other: "{{count}} cars",
+        });
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => r.path.endsWith('/locales/en/translation.json'))
+
+      expect(translationFile!.newTranslations).toEqual({
+        state_one: '{{count}} car',
+        state_other: '{{count}} cars',
+        state_test_one: '{{count}} car',
+        state_test_other: '{{count}} cars',
+        state_production_one: '{{count}} car',
+        state_production_other: '{{count}} cars',
+      })
+    })
   })
 
   it('should extract keys from a custom function with a member expression (i.e., i18n.t)', async () => {


### PR DESCRIPTION
Support combining context and plural options (`count`)

Fixes #33

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)