### PR TITLE
use namespace from <Trans /> i18nKey for consistency

### DIFF
--- a/test/extractor.Trans.test.ts
+++ b/test/extractor.Trans.test.ts
@@ -65,6 +65,28 @@ describe('extractor: advanced Trans features', () => {
     })
   })
 
+  it('should use ns from key instead of t prop', async () => {
+    const sampleCode = `
+      import React from 'react';
+      import { Trans, useTranslation } from 'react-i18next'
+
+      function MyComponent() {
+        const { t } = useTranslation('myNamespace');
+
+        return <Trans t={t} i18nKey="myOtherNamespace:myKey">Hello World</Trans>;
+      }
+    `
+    vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+    const results = await extract(mockConfig)
+    const myNamespaceFile = results.find(r => r.path.endsWith('/locales/en/myOtherNamespace.json'))
+
+    expect(myNamespaceFile).toBeDefined()
+    expect(myNamespaceFile!.newTranslations).toEqual({
+      myKey: 'Hello World',
+    })
+  })
+
   it('should generate plural keys when Trans component has a count prop', async () => {
     const sampleCode = `
       <Trans i18nKey="userMessagesUnread" count={count}>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Follow up on #35 - the same should be true for `<Trans />`. (I had this fix in a later commit... oops)

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)