### PR TITLE
Some repo suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ dist/*
 !dist/deno/
 
 .env.*
+.node-version
+.nvmrc
 
 coverage
 tryme.js

--- a/.npmignore
+++ b/.npmignore
@@ -13,6 +13,8 @@ typedoc.json
 .github
 .env
 .env.*
+.node-version
+.nvmrc
 eslint.config.js
 rollup.config.js
 vitest.config.js

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,22 @@
 {
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[javascriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  // enable ESLint formatting
+  "eslint.format.enable": true, 
   // run ESLint “fix” on save
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-
   // ensure ESLint runs when you save .js/.jsx/.ts/.tsx files
   "eslint.validate": [
     "javascript",
@@ -11,6 +24,6 @@
     "typescript",
     "typescriptreact"
   ],
-  "eslint.run": "onSave",            // run linting on save
-  "eslint.alwaysShowStatus": true    // show the ESLint status in the status bar
+  // run linting on save
+  "eslint.run": "onSave"
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./types/index.d.ts",
+  "engines": {
+    "node": ">=22"
+  },
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
Happy to change these, just some suggestions from bootstrapping

- Add `.node-version` for https://mise.jdx.dev/ (or other tooling) ... alt. happy to add `.node-version` to the `.gitignore` if that would be OK
  - This just makes the node version switch automatic which is convenient bc most of my projects are 20/22
- Disable VSCode's default formatting (or any formatting extension) - we use [Prettier](https://prettier.io/) internally - to avoid VSCode "fixing" whitespace in the repo. ESLint's "fix all on save" still works as it doesn't use VSCode's "format" hook.
- Add `engines` to clarify the minimum node version for consuming repos (20 worked for me and is LTS)

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [ ] run tests `npm run test`
- [ ] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)