### PR TITLE
fix handling of empty strings in template literals

### DIFF
--- a/src/extractor/parsers/ast-visitors.ts
+++ b/src/extractor/parsers/ast-visitors.ts
@@ -758,8 +758,8 @@ export class ASTVisitors {
           const ordinalAttr = node.opening.attributes?.find(
             (attr) =>
               attr.type === 'JSXAttribute' &&
-            attr.name.type === 'Identifier' &&
-            attr.name.value === 'ordinal'
+              attr.name.type === 'Identifier' &&
+              attr.name.value === 'ordinal'
           )
           const isOrdinal = !!ordinalAttr
 
@@ -802,8 +802,8 @@ export class ASTVisitors {
           const ordinalAttr = node.opening.attributes?.find(
             (attr) =>
               attr.type === 'JSXAttribute' &&
-            attr.name.type === 'Identifier' &&
-            attr.name.value === 'ordinal'
+              attr.name.type === 'Identifier' &&
+              attr.name.value === 'ordinal'
           )
           const isOrdinal = !!ordinalAttr
 
@@ -988,17 +988,18 @@ export class ASTVisitors {
    *
    * @private
    * @param expression - The SWC AST expression node to resolve
+   * @param returnEmptyStrings - Whether to include empty strings in the result
    * @returns An array of possible string values that the expression may produce.
    */
-  private resolvePossibleStringValues (expression: Expression): string[] {
+  private resolvePossibleStringValues (expression: Expression, returnEmptyStrings = false): string[] {
     if (expression.type === 'StringLiteral') {
       // Filter out empty strings as they should be treated as "no context" like i18next does
-      return expression.value ? [expression.value] : []
+      return expression.value || returnEmptyStrings ? [expression.value] : []
     }
 
     if (expression.type === 'ConditionalExpression') { // This is a ternary operator
-      const consequentValues = this.resolvePossibleStringValues(expression.consequent)
-      const alternateValues = this.resolvePossibleStringValues(expression.alternate)
+      const consequentValues = this.resolvePossibleStringValues(expression.consequent, returnEmptyStrings)
+      const alternateValues = this.resolvePossibleStringValues(expression.alternate, returnEmptyStrings)
       return [...consequentValues, ...alternateValues]
     }
 
@@ -1040,7 +1041,7 @@ export class ASTVisitors {
       (heads, expression, i) => {
         return heads.flatMap((head) => {
           const tail = tails[i]?.cooked ?? ''
-          return this.resolvePossibleStringValues(expression).map(
+          return this.resolvePossibleStringValues(expression, true).map(
             (expressionValue) => `${head}${expressionValue}${tail}`
           )
         })

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -349,6 +349,31 @@ describe('extractor: advanced t features', () => {
       })
     })
 
+    it('should correctly handle empty strings in template literal', async () => {
+      const sampleCode = `
+        const hasProducts = false;
+        const isAvailable = true;
+
+        t(\`section.intro.header.marketing\${isAvailable ? '.available' : ''}\`)
+        t(\`section.intro.header.\${
+                  hasProducts ? 'products' : 'no-products'
+              }\${isAvailable ? '.available' : ''}\`)
+        `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract({ ...mockConfig, extract: { ...mockConfig.extract, keySeparator: false, } })
+      const translationFile = results.find(r => r.path.endsWith('/locales/en/translation.json'))
+
+      expect(translationFile!.newTranslations).toEqual({
+        'section.intro.header.marketing': 'section.intro.header.marketing',
+        'section.intro.header.marketing.available': 'section.intro.header.marketing.available',
+        'section.intro.header.no-products': 'section.intro.header.no-products',
+        'section.intro.header.no-products.available': 'section.intro.header.no-products.available',
+        'section.intro.header.products': 'section.intro.header.products',
+        'section.intro.header.products.available': 'section.intro.header.products.available',
+      })
+    })
+
     it('should extract keys from t() calls inside array.map in JSX', async () => {
       const sampleCode = `
         function MappedComponent() {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

The fix in c506769547e372684463b7966a465b66c0c3ea28 and #39 were not entirely compatible since `resolvePossibleStringValues` was re-used. I use flat strings in most projects so stumbled upon this debugging `""` elsewhere. The test suite also seemed to miss this edge case.

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)