### PR TITLE
Allow translating dynamic variables in TypeScript with `as`/`satisfies`

### DIFF
--- a/test/extractor.processFile.test.ts
+++ b/test/extractor.processFile.test.ts
@@ -118,52 +118,6 @@ describe('processFile', () => {
     expect(allKeys.size).toBeGreaterThan(0)
   })
 
-  it('should handle TypeScript satisfies operator in template literals', async () => {
-    const sampleCode = `
-      const role = 'ADMIN';
-      t(\`profile.role.\${role satisfies 'ADMIN' | 'MANAGER' | 'EMPLOYEE'}.description\`);
-    `
-
-    vol.fromJSON({
-      '/src/satisfies-test.ts': sampleCode,
-    })
-
-    const plugins: Plugin[] = []
-
-    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
-
-    await processFile('/src/satisfies-test.ts', plugins, astVisitors, pluginContext, mockConfig)
-
-    expect(astVisitors.visit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'Module'
-      })
-    )
-  })
-
-  it('should handle TypeScript as operator in template literals', async () => {
-    const sampleCode = `
-      const status = getStatus();
-      t(\`alert.\${status as 'success' | 'error' | 'warning'}.message\`);
-    `
-
-    vol.fromJSON({
-      '/src/as-test.ts': sampleCode,
-    })
-
-    const plugins: Plugin[] = []
-
-    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
-
-    await processFile('/src/as-test.ts', plugins, astVisitors, pluginContext, mockConfig)
-
-    expect(astVisitors.visit).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'Module'
-      })
-    )
-  })
-
   it('should parse JSX syntax correctly', async () => {
     const sampleCode = `
       import { Trans } from 'react-i18next';

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -357,6 +357,33 @@ describe('extractor: advanced t features', () => {
       })
     })
 
+    it('should extract keys from template string with annotated variable', async () => {
+      const sampleCode = `
+        const state = 'pending';
+
+        t(\`states.\${state satisfies 'pending' | 'finalized'}.description\`);
+        t(\`states.\${state as 'baseball'}.description\`);
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => r.path.endsWith('/locales/en/translation.json'))
+
+      expect(translationFile!.newTranslations).toEqual({
+        states: {
+          pending: {
+            description: 'states.pending.description',
+          },
+          finalized: {
+            description: 'states.finalized.description',
+          },
+          baseball: {
+            description: 'states.baseball.description',
+          },
+        },
+      })
+    })
+
     it('should extract all possible keys with nested expressions', async () => {
       const sampleCode = `
         const test = false;


### PR DESCRIPTION
Adds support for `variable satisfies 'key'` and `variable as 'key'`

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [ ] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)