### PR TITLE
run plugins onVisitNode during ast walking

### DIFF
--- a/src/extractor/plugin-manager.ts
+++ b/src/extractor/plugin-manager.ts
@@ -1,4 +1,4 @@
-import type { ExtractedKey, PluginContext, I18nextToolkitConfig, Logger } from '../types'
+import type { ExtractedKey, PluginContext, I18nextToolkitConfig, Logger, Plugin } from '../types'
 
 /**
  * Initializes an array of plugins by calling their setup hooks.
@@ -39,7 +39,12 @@ export async function initializePlugins (plugins: any[]): Promise<void> {
  * })
  * ```
  */
-export function createPluginContext (allKeys: Map<string, ExtractedKey>, config: I18nextToolkitConfig, logger: Logger): PluginContext {
+export function createPluginContext (allKeys: Map<string, ExtractedKey>, plugins: Plugin[], config: Omit<I18nextToolkitConfig, 'plugins'>, logger: Logger): PluginContext {
+  const pluginContextConfig = Object.freeze({
+    ...config,
+    plugins: [...plugins],
+  })
+
   return {
     addKey: (keyInfo: ExtractedKey) => {
       // Use namespace in the unique map key to avoid collisions across namespaces
@@ -50,7 +55,7 @@ export function createPluginContext (allKeys: Map<string, ExtractedKey>, config:
         allKeys.set(uniqueKey, { ...keyInfo, defaultValue })
       }
     },
-    config,
+    config: pluginContextConfig,
     logger,
     // This will be attached later, so we provide a placeholder
     getVarFromScope: () => undefined,

--- a/test/extractor.findKeys.test.ts
+++ b/test/extractor.findKeys.test.ts
@@ -1,7 +1,9 @@
 import { vol } from 'memfs'
-import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { vi, describe, it, expect, beforeEach, type Mock } from 'vitest'
+import type { Expression } from '@swc/core'
 import { findKeys } from '../src/index'
-import type { I18nextToolkitConfig } from '../src/index'
+import type { I18nextToolkitConfig, Plugin, PluginContext } from '../src/index'
+import type { ScopeInfo } from '../src/types'
 
 vi.mock('fs/promises', async () => {
   const memfs = await vi.importActual<typeof import('memfs')>('memfs')
@@ -24,11 +26,14 @@ const mockConfig: I18nextToolkitConfig = {
 }
 
 describe('extractor.findKeys', () => {
+  let mockGlob!: Mock
+
   beforeEach(async () => {
     vol.reset()
     vi.clearAllMocks()
+
     const { glob } = await import('glob')
-    ;(glob as any).mockResolvedValue(['/src/App.tsx'])
+    mockGlob = vi.mocked(glob)
   })
 
   it('extracts keys from t() and Trans with default values preserved', async () => {
@@ -47,6 +52,9 @@ describe('extractor.findKeys', () => {
         );
       }
     `
+
+    mockGlob.mockResolvedValue(['/src/App.tsx'])
+
     vol.fromJSON({
       '/src/App.tsx': sampleCode,
     })
@@ -66,5 +74,200 @@ describe('extractor.findKeys', () => {
     // Both keys should belong to the default namespace
     expect(title?.ns).toBe('translation')
     expect(desc?.ns).toBe('translation')
+  })
+
+  it('should call plugin onVisitNode hooks for each AST node', async () => {
+    const onVisitNodeSpy = vi.fn()
+    const visitPlugin: Plugin = {
+      name: 'visit-plugin',
+      onVisitNode: onVisitNodeSpy
+    }
+
+    const configWithPlugin = {
+      ...mockConfig,
+      plugins: [visitPlugin]
+    }
+
+    mockGlob.mockResolvedValue(['/src/test.ts'])
+
+    const sampleCode = `
+        function test() {
+          const x = 'hello';
+          return x;
+        }
+      `
+
+    vol.fromJSON({
+      '/src/test.ts': sampleCode,
+    })
+
+    await findKeys(configWithPlugin)
+
+    expect(onVisitNodeSpy).toHaveBeenCalled()
+    // Should be called multiple times for different AST nodes
+    expect(onVisitNodeSpy.mock.calls.length).toBeGreaterThan(1)
+  })
+
+  it('should provide plugin context with scope access to plugins', async () => {
+    let capturedContext!: PluginContext
+    let capturedScopeInfo!: ScopeInfo | undefined
+    const scopeAccessPlugin: Plugin = {
+      name: 'scope-access-plugin',
+      onVisitNode: (node, context) => {
+        const expression = node as Expression
+
+        if (expression.type === 'CallExpression' && expression.callee.type === 'Identifier' && expression.callee.value === 't') {
+          capturedContext = context
+          capturedScopeInfo = context.getVarFromScope('t')
+        }
+      }
+    }
+
+    const configWithPlugin = {
+      ...mockConfig,
+      plugins: [scopeAccessPlugin]
+    }
+
+    mockGlob.mockResolvedValue(['/src/App.tsx'])
+
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function App() {
+        const { t } = useTranslation('common');
+        return (
+          <div>
+            <h1>{t('app.title', { defaultValue: 'Welcome!' })}</h1>
+            <Trans i18nKey="app.description">
+              This is a <strong>description</strong>.
+            </Trans>
+          </div>
+        );
+      }
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    await findKeys(configWithPlugin)
+
+    expect(capturedContext).toBeDefined()
+    expect(capturedContext.getVarFromScope).toBeDefined()
+    expect(typeof capturedContext.getVarFromScope).toBe('function')
+
+    expect(capturedScopeInfo).toEqual({ defaultNs: 'common', keyPrefix: undefined })
+  })
+
+  it('should allow plugins to access parsed translation options', async () => {
+    let capturedContext: any
+    const optionsAccessPlugin: Plugin = {
+      name: 'options-access-plugin',
+      onVisitNode: (node, context) => {
+        capturedContext = context
+        // Plugin can add keys with full context
+        if (node.type === 'CallExpression') {
+          context.addKey({
+            key: 'plugin.extracted.key',
+            defaultValue: 'Plugin Value',
+            ns: 'custom'
+          })
+        }
+      }
+    }
+
+    const configWithPlugin = {
+      ...mockConfig,
+      plugins: [optionsAccessPlugin]
+    }
+
+    const sampleCode = `
+          t('test.key', { defaultValue: 'Test', count: 1, context: 'male' });
+        `
+
+    mockGlob.mockResolvedValue(['/src/options-test.ts'])
+
+    vol.fromJSON({
+      '/src/options-test.ts': sampleCode,
+    })
+
+    const { allKeys } = await findKeys(configWithPlugin)
+
+    expect(capturedContext).toBeDefined()
+    expect(capturedContext.addKey).toBeDefined()
+    expect(capturedContext.config).toEqual(configWithPlugin)
+
+    // Verify plugin could add a key
+    expect(allKeys.has('custom:plugin.extracted.key')).toBe(true)
+  })
+
+  it('should handle plugin errors gracefully', async () => {
+    const faultyPlugin: Plugin = {
+      name: 'faulty-plugin',
+      onLoad: vi.fn().mockRejectedValue(new Error('Load failed')),
+      onVisitNode: vi.fn().mockImplementation(() => {
+        throw new Error('Visit failed')
+      })
+    }
+
+    const configWithFaultyPlugin = {
+      ...mockConfig,
+      plugins: [faultyPlugin]
+    }
+
+    mockGlob.mockResolvedValue(['/src/test.ts'])
+
+    const sampleCode = 'const x = 1;'
+
+    vol.fromJSON({
+      '/src/test.ts': sampleCode,
+    })
+
+    // Should not throw, but handle errors gracefully
+    await expect(findKeys(configWithFaultyPlugin))
+      .resolves.not.toThrow()
+  })
+
+  it('should support multiple plugins working together', async () => {
+    const plugin1Spy = vi.fn()
+    const plugin2Spy = vi.fn()
+
+    const plugin1: Plugin = {
+      name: 'plugin-1',
+      onLoad: plugin1Spy.mockImplementation((code) => `// Plugin 1\n${code}`),
+      onVisitNode: plugin1Spy
+    }
+
+    const plugin2: Plugin = {
+      name: 'plugin-2',
+      onLoad: plugin2Spy.mockImplementation((code) => `// Plugin 2\n${code}`),
+      onVisitNode: plugin2Spy
+    }
+
+    const configWithPlugins = {
+      ...mockConfig,
+      plugins: [plugin1, plugin2]
+    }
+
+    mockGlob.mockResolvedValue(['/src/multi-test.ts'])
+
+    const sampleCode = 't(\'multi.plugin.test\');'
+
+    vol.fromJSON({
+      '/src/multi-test.ts': sampleCode,
+    })
+
+    await findKeys(configWithPlugins)
+
+    // Both plugins should have been called for onLoad
+    expect(plugin1Spy).toHaveBeenCalledWith(sampleCode, '/src/multi-test.ts')
+    expect(plugin2Spy).toHaveBeenCalledWith(
+      expect.stringContaining('// Plugin 1'),
+      '/src/multi-test.ts'
+    )
+
+    // Both plugins should have been called for onVisitNode
+    expect(plugin1Spy.mock.calls.length).toBeGreaterThan(1)
+    expect(plugin2Spy.mock.calls.length).toBeGreaterThan(1)
   })
 })

--- a/test/extractor.processFile.test.ts
+++ b/test/extractor.processFile.test.ts
@@ -2,6 +2,8 @@ import { vol } from 'memfs'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 import { processFile } from '../src/extractor/core/extractor'
 import { ASTVisitors } from '../src/extractor/parsers/ast-visitors'
+import { createPluginContext } from '../src/extractor/plugin-manager'
+import { ConsoleLogger } from '../src/utils/logger'
 import type { I18nextToolkitConfig, ExtractedKey, Plugin } from '../src/index'
 
 vi.mock('fs/promises', async () => {
@@ -33,7 +35,7 @@ describe('processFile', () => {
     astVisitors = {
       visit: vi.fn(),
       getVarFromScope: vi.fn().mockReturnValue(undefined),
-      objectKeys: new Set()
+      objectKeys: new Set(),
     } as any
   })
 
@@ -51,7 +53,11 @@ describe('processFile', () => {
       '/src/App.tsx': sampleCode,
     })
 
-    await processFile('/src/App.tsx', mockConfig, allKeys, astVisitors)
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await processFile('/src/App.tsx', plugins, astVisitors, pluginContext, mockConfig)
 
     expect(astVisitors.visit).toHaveBeenCalledTimes(1)
     expect(astVisitors.visit).toHaveBeenCalledWith(
@@ -75,11 +81,15 @@ describe('processFile', () => {
       plugins: [transformPlugin]
     }
 
+    const plugins = configWithPlugin.plugins
+
     vol.fromJSON({
       '/src/test.ts': originalCode,
     })
 
-    await processFile('/src/test.ts', configWithPlugin, allKeys, astVisitors)
+    const pluginContext = createPluginContext(allKeys, plugins, configWithPlugin, new ConsoleLogger())
+
+    await processFile('/src/test.ts', plugins, astVisitors, pluginContext, configWithPlugin)
 
     expect(transformPlugin.onLoad).toHaveBeenCalledWith(originalCode, '/src/test.ts')
     expect(astVisitors.visit).toHaveBeenCalledTimes(1)
@@ -98,73 +108,14 @@ describe('processFile', () => {
       '/src/test.ts': sampleCode,
     })
 
-    await processFile('/src/test.ts', mockConfig, allKeys, astVisitors)
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await processFile('/src/test.ts', plugins, astVisitors, pluginContext, mockConfig)
 
     // Keys should be added to allKeys map through the plugin context
     expect(allKeys.size).toBeGreaterThan(0)
-  })
-
-  it('should call plugin onVisitNode hooks for each AST node', async () => {
-    const onVisitNodeSpy = vi.fn()
-    const visitPlugin: Plugin = {
-      name: 'visit-plugin',
-      onVisitNode: onVisitNodeSpy
-    }
-
-    const configWithPlugin = {
-      ...mockConfig,
-      plugins: [visitPlugin]
-    }
-
-    const sampleCode = `
-      function test() {
-        const x = 'hello';
-        return x;
-      }
-    `
-
-    vol.fromJSON({
-      '/src/test.ts': sampleCode,
-    })
-
-    await processFile('/src/test.ts', configWithPlugin, allKeys, astVisitors)
-
-    expect(onVisitNodeSpy).toHaveBeenCalled()
-    // Should be called multiple times for different AST nodes
-    expect(onVisitNodeSpy.mock.calls.length).toBeGreaterThan(1)
-  })
-
-  it('should provide plugin context with scope access to plugins', async () => {
-    const mockScopeInfo = { type: 'useTranslation', ns: 'common' }
-    astVisitors.getVarFromScope = vi.fn().mockReturnValue(mockScopeInfo)
-
-    let capturedContext: any
-    const scopeAccessPlugin: Plugin = {
-      name: 'scope-access-plugin',
-      onVisitNode: (node, context) => {
-        capturedContext = context
-      }
-    }
-
-    const configWithPlugin = {
-      ...mockConfig,
-      plugins: [scopeAccessPlugin]
-    }
-
-    vol.fromJSON({
-      '/src/test.ts': 'const x = 1;',
-    })
-
-    await processFile('/src/test.ts', configWithPlugin, allKeys, astVisitors)
-
-    expect(capturedContext).toBeDefined()
-    expect(capturedContext.getVarFromScope).toBeDefined()
-    expect(typeof capturedContext.getVarFromScope).toBe('function')
-
-    // Test that the scope function works
-    const scopeResult = capturedContext.getVarFromScope('testVar')
-    expect(astVisitors.getVarFromScope).toHaveBeenCalledWith('testVar')
-    expect(scopeResult).toEqual(mockScopeInfo)
   })
 
   it('should handle TypeScript satisfies operator in template literals', async () => {
@@ -177,7 +128,11 @@ describe('processFile', () => {
       '/src/satisfies-test.ts': sampleCode,
     })
 
-    await processFile('/src/satisfies-test.ts', mockConfig, allKeys, astVisitors)
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await processFile('/src/satisfies-test.ts', plugins, astVisitors, pluginContext, mockConfig)
 
     expect(astVisitors.visit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -196,119 +151,17 @@ describe('processFile', () => {
       '/src/as-test.ts': sampleCode,
     })
 
-    await processFile('/src/as-test.ts', mockConfig, allKeys, astVisitors)
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await processFile('/src/as-test.ts', plugins, astVisitors, pluginContext, mockConfig)
 
     expect(astVisitors.visit).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'Module'
       })
     )
-  })
-
-  it('should allow plugins to access parsed translation options', async () => {
-    let capturedContext: any
-    const optionsAccessPlugin: Plugin = {
-      name: 'options-access-plugin',
-      onVisitNode: (node, context) => {
-        capturedContext = context
-        // Plugin can add keys with full context
-        if (node.type === 'CallExpression') {
-          context.addKey({
-            key: 'plugin.extracted.key',
-            defaultValue: 'Plugin Value',
-            ns: 'custom'
-          })
-        }
-      }
-    }
-
-    const configWithPlugin = {
-      ...mockConfig,
-      plugins: [optionsAccessPlugin]
-    }
-
-    const sampleCode = `
-      t('test.key', { defaultValue: 'Test', count: 1, context: 'male' });
-    `
-
-    vol.fromJSON({
-      '/src/options-test.ts': sampleCode,
-    })
-
-    await processFile('/src/options-test.ts', configWithPlugin, allKeys, astVisitors)
-
-    expect(capturedContext).toBeDefined()
-    expect(capturedContext.addKey).toBeDefined()
-    expect(capturedContext.config).toEqual(configWithPlugin)
-
-    // Verify plugin could add a key
-    expect(allKeys.has('custom:plugin.extracted.key')).toBe(true)
-  })
-
-  it('should handle plugin errors gracefully', async () => {
-    const faultyPlugin: Plugin = {
-      name: 'faulty-plugin',
-      onLoad: vi.fn().mockRejectedValue(new Error('Load failed')),
-      onVisitNode: vi.fn().mockImplementation(() => {
-        throw new Error('Visit failed')
-      })
-    }
-
-    const configWithFaultyPlugin = {
-      ...mockConfig,
-      plugins: [faultyPlugin]
-    }
-
-    const sampleCode = 'const x = 1;'
-
-    vol.fromJSON({
-      '/src/test.ts': sampleCode,
-    })
-
-    // Should not throw, but handle errors gracefully
-    await expect(processFile('/src/test.ts', configWithFaultyPlugin, allKeys, astVisitors))
-      .resolves.not.toThrow()
-  })
-
-  it('should support multiple plugins working together', async () => {
-    const plugin1Spy = vi.fn()
-    const plugin2Spy = vi.fn()
-
-    const plugin1: Plugin = {
-      name: 'plugin-1',
-      onLoad: plugin1Spy.mockImplementation((code) => `// Plugin 1\n${code}`),
-      onVisitNode: plugin1Spy
-    }
-
-    const plugin2: Plugin = {
-      name: 'plugin-2',
-      onLoad: plugin2Spy.mockImplementation((code) => `// Plugin 2\n${code}`),
-      onVisitNode: plugin2Spy
-    }
-
-    const configWithPlugins = {
-      ...mockConfig,
-      plugins: [plugin1, plugin2]
-    }
-
-    const sampleCode = 't(\'multi.plugin.test\');'
-
-    vol.fromJSON({
-      '/src/multi-test.ts': sampleCode,
-    })
-
-    await processFile('/src/multi-test.ts', configWithPlugins, allKeys, astVisitors)
-
-    // Both plugins should have been called for onLoad
-    expect(plugin1Spy).toHaveBeenCalledWith(sampleCode, '/src/multi-test.ts')
-    expect(plugin2Spy).toHaveBeenCalledWith(
-      expect.stringContaining('// Plugin 1'),
-      '/src/multi-test.ts'
-    )
-
-    // Both plugins should have been called for onVisitNode
-    expect(plugin1Spy.mock.calls.length).toBeGreaterThan(1)
-    expect(plugin2Spy.mock.calls.length).toBeGreaterThan(1)
   })
 
   it('should parse JSX syntax correctly', async () => {
@@ -328,7 +181,11 @@ describe('processFile', () => {
       '/src/jsx-test.tsx': sampleCode,
     })
 
-    await processFile('/src/jsx-test.tsx', mockConfig, allKeys, astVisitors)
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await processFile('/src/jsx-test.tsx', plugins, astVisitors, pluginContext, mockConfig)
 
     expect(astVisitors.visit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -351,7 +208,11 @@ describe('processFile', () => {
       '/src/decorator-test.ts': sampleCode,
     })
 
-    await processFile('/src/decorator-test.ts', mockConfig, allKeys, astVisitors)
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await processFile('/src/decorator-test.ts', plugins, astVisitors, pluginContext, mockConfig)
 
     expect(astVisitors.visit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -370,12 +231,20 @@ describe('processFile', () => {
       '/src/invalid.ts': invalidCode,
     })
 
-    await expect(processFile('/src/invalid.ts', mockConfig, allKeys, astVisitors))
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await expect(processFile('/src/invalid.ts', plugins, astVisitors, pluginContext, mockConfig))
       .rejects.toThrow('Failed to process file')
   })
 
   it('should throw ExtractorError when file does not exist', async () => {
-    await expect(processFile('/nonexistent/file.ts', mockConfig, allKeys, astVisitors))
+    const plugins = []
+
+    const pluginContext = createPluginContext(allKeys, plugins, mockConfig, new ConsoleLogger())
+
+    await expect(processFile('/nonexistent/file.ts', plugins, astVisitors, pluginContext, mockConfig))
       .rejects.toThrow('Failed to process file')
   })
 
@@ -428,7 +297,11 @@ describe('processFile', () => {
       '/src/satisfies-plugin-test.ts': sampleCode,
     })
 
-    await processFile('/src/satisfies-plugin-test.ts', configWithSatisfiesPlugin, allKeys, astVisitors)
+    const plugins = configWithSatisfiesPlugin.plugins
+
+    const pluginContext = createPluginContext(allKeys, plugins, configWithSatisfiesPlugin, new ConsoleLogger())
+
+    await processFile('/src/satisfies-plugin-test.ts', plugins, astVisitors, pluginContext, configWithSatisfiesPlugin)
 
     // Verify that the plugin could potentially extract keys from satisfies expressions
     expect(extractedKeys.length).toBeGreaterThanOrEqual(0)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

@adrai this made it "work" for me - it required a bit of shuffling though. I also unified the plugin context creation so there is only 1 context per run. I started worrying a bit about passing the same object/array references to plugins, though I didn't go too far down that path 😅 

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)