### PR TITLE
loosen context value parsing

### DIFF
--- a/src/extractor/parsers/ast-visitors.ts
+++ b/src/extractor/parsers/ast-visitors.ts
@@ -456,7 +456,16 @@ export class ASTVisitors {
         const keysWithContext: ExtractedKey[] = []
 
         // 1. Handle Context
-        if (contextProp?.value?.type === 'ConditionalExpression') {
+        if (contextProp?.value?.type === 'StringLiteral' || contextProp?.value.type === 'NumericLiteral' || contextProp?.value.type === 'BooleanLiteral') {
+          // If the context is static, we don't need to add the base key
+          const contextValue = `${contextProp.value.value}`
+
+          const contextSeparator = this.config.extract.contextSeparator ?? '_'
+          // Ignore context: ''
+          if (contextValue !== '') {
+            keysWithContext.push({ key: `${finalKey}${contextSeparator}${contextValue}`, ns, defaultValue: dv })
+          }
+        } else if (contextProp?.value) {
           const contextValues = this.resolvePossibleStringValues(contextProp.value)
           const contextSeparator = this.config.extract.contextSeparator ?? '_'
 
@@ -467,11 +476,6 @@ export class ASTVisitors {
             // For dynamic context, also add the base key as a fallback
             keysWithContext.push({ key: finalKey, ns, defaultValue: dv })
           }
-        } else if (contextProp?.value?.type === 'StringLiteral') {
-          const contextValue = contextProp.value.value
-
-          const contextSeparator = this.config.extract.contextSeparator ?? '_'
-          keysWithContext.push({ key: `${finalKey}${contextSeparator}${contextValue}`, ns, defaultValue: dv })
         }
 
         // 2. Handle Plurals


### PR DESCRIPTION
we support multiple types of expressions now so no need to guard by conditionals, this enables template strings in contexts. also fixes a bug where context of `''` (explicit) still triggered #34.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)