### PR TITLE
Add extractKeysFromExpression plugin option

### DIFF
--- a/src/extractor/core/extractor.ts
+++ b/src/extractor/core/extractor.ts
@@ -59,6 +59,8 @@ export async function runExtractor (
 
   validateExtractorConfig(config)
 
+  const plugins = config.plugins || []
+
   const spinner = ora('Running i18next key extractor...\n').start()
 
   try {
@@ -86,9 +88,9 @@ export async function runExtractor (
     }
 
     // Run afterSync hooks from plugins
-    if ((config.plugins || []).length > 0) {
+    if (plugins.length > 0) {
       spinner.text = 'Running post-extraction plugins...'
-      for (const plugin of (config.plugins || [])) {
+      for (const plugin of plugins) {
         await plugin.afterSync?.(results, config)
       }
     }

--- a/src/extractor/core/key-finder.ts
+++ b/src/extractor/core/key-finder.ts
@@ -1,4 +1,5 @@
 import { glob } from 'glob'
+import type { Expression } from '@swc/core'
 import type { ExtractedKey, Logger, I18nextToolkitConfig } from '../../types'
 import { processFile } from './extractor'
 import { ConsoleLogger } from '../../utils/logger'
@@ -56,6 +57,26 @@ export async function findKeys (
           logger.warn(`Plugin ${plugin.name} onVisitNode failed:`, err)
         }
       }
+    },
+    resolvePossibleKeyStringValues: (expression: Expression) => {
+      return plugins.flatMap(plugin => {
+        try {
+          return plugin.extractKeysFromExpression?.(expression, config, logger) ?? []
+        } catch (err) {
+          logger.warn(`Plugin ${plugin.name} extractKeysFromExpression failed:`, err)
+          return []
+        }
+      })
+    },
+    resolvePossibleContextStringValues: (expression: Expression) => {
+      return plugins.flatMap(plugin => {
+        try {
+          return plugin.extractContextFromExpression?.(expression, config, logger) ?? []
+        } catch (err) {
+          logger.warn(`Plugin ${plugin.name} extractContextFromExpression failed:`, err)
+          return []
+        }
+      })
     },
   } satisfies ASTVisitorHooks
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -197,6 +197,32 @@ export interface Plugin {
   name: string;
 
   /**
+   * Custom function to extract keys from an AST expression. Useful
+   * for plugins that need to extract key patterns from `t(..., options)`
+   * or `<Trans i18nKey={...} />`.
+   *
+   * @param expression - An expression to extract keys from
+   * @param config - The i18next toolkit configuration object
+   * @param logger - Logger instance for output
+   *
+   * @returns An array of extracted keys
+   */
+  extractKeysFromExpression?: (expression: Expression, config: Omit<I18nextToolkitConfig, 'plugins'>, logger: Logger) => string[];
+
+  /**
+   * Custom function to extract context from an AST expression. Useful
+   * for plugins that need to extract context patterns from `t('key', { context: ... })`
+   * or `<Trans i18nKey="key" context={...} />`.
+   *
+   * @param expression - An expression to extract context from
+   * @param config - The i18next toolkit configuration object
+   * @param logger - Logger instance for output
+   *
+   * @returns An array of extracted context values
+   */
+  extractContextFromExpression?: (expression: Expression, config: Omit<I18nextToolkitConfig, 'plugins'>, logger: Logger) => string[];
+
+  /**
    * Hook called once at the beginning of the extraction process.
    * Use for initialization tasks like setting up resources or validating configuration.
    */

--- a/test/plugin.extractContextFromExpression.test.ts
+++ b/test/plugin.extractContextFromExpression.test.ts
@@ -1,0 +1,339 @@
+import { vol } from 'memfs'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import type { Expression } from '@swc/core'
+import { findKeys } from '../src/index'
+import type { I18nextToolkitConfig, Plugin, Logger } from '../src/types'
+
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+vi.mock('glob', () => ({ glob: vi.fn() }))
+
+describe('plugin system: extractContextFromExpression', () => {
+  beforeEach(async () => {
+    vol.reset()
+    vi.clearAllMocks()
+    vi.spyOn(process, 'cwd').mockReturnValue('/')
+    const { glob } = await import('glob')
+    vi.mocked(glob).mockResolvedValue(['/src/App.tsx'])
+  })
+
+  it('should extract context values from conditional expressions', async () => {
+    const sampleCode = `
+      const userType = 'admin';
+      t('greeting', { context: userType === 'admin' ? 'admin' : 'user' });
+      t('message', { context: 'default' });
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const conditionalContextPlugin = (): Plugin => ({
+      name: 'conditional-context-extractor',
+      extractContextFromExpression: (expression: Expression, config, logger: Logger) => {
+        const contexts: string[] = []
+
+        // Handle conditional expressions (ternary operators)
+        if (expression.type === 'ConditionalExpression') {
+          if (expression.consequent.type === 'StringLiteral') {
+            contexts.push(expression.consequent.value)
+          }
+          if (expression.alternate.type === 'StringLiteral') {
+            contexts.push(expression.alternate.value)
+          }
+        }
+
+        return contexts
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [conditionalContextPlugin()],
+    }
+
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    // Should extract base keys (for dynamic context) and context variants
+    expect(extractedKeys).toContain('greeting')
+    expect(extractedKeys).toContain('greeting_admin')
+    expect(extractedKeys).toContain('greeting_user')
+    // Static context only generates the context variant, not the base key
+    expect(extractedKeys).toContain('message_default')
+  })
+
+  it('should extract context from template literals with variable names', async () => {
+    const sampleCode = `
+      const role = 'manager';
+      const level = 'senior';
+      t('title', { context: \`\${role}.\${level}\` });
+      t('label', { context: 'static' });
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const templateContextPlugin = (): Plugin => ({
+      name: 'template-context-extractor',
+      extractContextFromExpression: (expression: Expression, config, logger: Logger) => {
+        const contexts: string[] = []
+
+        if (expression.type === 'TemplateLiteral') {
+          const joins = expression.quasis.map(quasi => quasi.cooked)
+          const parts = expression.expressions.map(expr =>
+            expr.type === 'Identifier' ? expr.value : 'unknown'
+          )
+
+          if (parts.length > 0) {
+            const reconstructed = joins.reduce<string>(
+              (acc, join, i) => acc + (join || '') + (parts[i] || ''),
+              ''
+            )
+            contexts.push(reconstructed)
+          }
+        }
+
+        return contexts
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [templateContextPlugin()],
+    }
+
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    // Dynamic context adds both base key and context variants
+    expect(extractedKeys).toContain('title')
+    expect(extractedKeys).toContain('title_role.level')
+    // Static context only generates the context variant
+    expect(extractedKeys).toContain('label_static')
+  })
+
+  it('should handle multiple plugins with extractContextFromExpression', async () => {
+    const sampleCode = `
+      t('status', { context: condition ? 'active' : 'inactive' });
+      t('mode', { context: \`\${theme}\` });
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const conditionalPlugin = (): Plugin => ({
+      name: 'conditional-context-plugin',
+      extractContextFromExpression: (expression: Expression) => {
+        if (expression.type === 'ConditionalExpression') {
+          const contexts: string[] = []
+          if (expression.consequent.type === 'StringLiteral') {
+            contexts.push(expression.consequent.value)
+          }
+          if (expression.alternate.type === 'StringLiteral') {
+            contexts.push(expression.alternate.value)
+          }
+          return contexts
+        }
+        return []
+      },
+    })
+
+    const templatePlugin = (): Plugin => ({
+      name: 'template-context-plugin',
+      extractContextFromExpression: (expression: Expression) => {
+        if (expression.type === 'TemplateLiteral') {
+          return ['light', 'dark']
+        }
+        return []
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [conditionalPlugin(), templatePlugin()],
+    }
+
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    // Both plugins should contribute context variants
+    expect(extractedKeys).toContain('status_active')
+    expect(extractedKeys).toContain('status_inactive')
+    expect(extractedKeys).toContain('mode_light')
+    expect(extractedKeys).toContain('mode_dark')
+  })
+
+  it('should handle errors gracefully in extractContextFromExpression', async () => {
+    const sampleCode = `
+      t('key.normal', { context: 'valid' });
+      t('key.other', { context: someExpression });
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const faultyPlugin = (): Plugin => ({
+      name: 'faulty-context-plugin',
+      extractContextFromExpression: (expression: Expression) => {
+        throw new Error('Context extraction error!')
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [faultyPlugin()],
+    }
+
+    // Should not throw
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    // Keys should still be extracted despite plugin error
+    // Static context only generates context variant
+    expect(extractedKeys).toContain('key.normal_valid')
+    expect(extractedKeys).toContain('key.other')
+  })
+
+  it('should provide config and logger to extractContextFromExpression', async () => {
+    const sampleCode = `
+      t('button', { context: isActive ? 'enabled' : 'disabled' });
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const configSpy = vi.fn()
+    const loggerSpy = vi.fn()
+
+    const inspectorPlugin = (): Plugin => ({
+      name: 'inspector-context-plugin',
+      extractContextFromExpression: (expression: Expression, config, logger: Logger) => {
+        configSpy(config)
+        loggerSpy(logger)
+
+        if (expression.type === 'ConditionalExpression') {
+          const contexts: string[] = []
+          if (expression.consequent.type === 'StringLiteral') {
+            contexts.push(expression.consequent.value)
+          }
+          if (expression.alternate.type === 'StringLiteral') {
+            contexts.push(expression.alternate.value)
+          }
+          return contexts
+        }
+        return []
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [inspectorPlugin()],
+    }
+
+    await findKeys(config)
+
+    // Verify that the plugin received config and logger
+    expect(configSpy).toHaveBeenCalled()
+    expect(loggerSpy).toHaveBeenCalled()
+
+    const receivedConfig = configSpy.mock.calls[0][0]
+    expect(receivedConfig).toHaveProperty('locales')
+    expect(receivedConfig).toHaveProperty('extract')
+
+    const receivedLogger = loggerSpy.mock.calls[0][0]
+    expect(receivedLogger).toHaveProperty('warn')
+  })
+
+  it('should extract context from object property access', async () => {
+    const sampleCode = `
+      const CONTEXTS = { ADMIN: 'admin', USER: 'user', GUEST: 'guest' };
+      t('welcome', { context: CONTEXTS.ADMIN });
+      t('dashboard', { context: someVar ? CONTEXTS.USER : CONTEXTS.GUEST });
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const objectContextPlugin = (): Plugin => ({
+      name: 'object-context-extractor',
+      extractContextFromExpression: (expression: Expression) => {
+        const contexts: string[] = []
+
+        const extractFromMemberExpression = (expr: Expression) => {
+          if (expr.type === 'MemberExpression' &&
+              expr.object.type === 'Identifier' &&
+              expr.object.value === 'CONTEXTS' &&
+              expr.property.type === 'Identifier') {
+            const contextMap: Record<string, string> = {
+              ADMIN: 'admin',
+              USER: 'user',
+              GUEST: 'guest'
+            }
+            const propName = expr.property.value
+            if (propName in contextMap) {
+              contexts.push(contextMap[propName])
+            }
+          }
+        }
+
+        // Handle member expressions like CONTEXTS.ADMIN
+        extractFromMemberExpression(expression)
+
+        // Handle conditional expressions with member expressions in branches
+        if (expression.type === 'ConditionalExpression') {
+          extractFromMemberExpression(expression.consequent)
+          extractFromMemberExpression(expression.alternate)
+        }
+
+        return contexts
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [objectContextPlugin()],
+    }
+
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    // Static context from object property
+    expect(extractedKeys).toContain('welcome_admin')
+    // Dynamic context from conditional adds base key and context variants
+    expect(extractedKeys).toContain('dashboard')
+    expect(extractedKeys).toContain('dashboard_user')
+    expect(extractedKeys).toContain('dashboard_guest')
+  })
+})

--- a/test/plugin.extractKeysFromExpression.test.ts
+++ b/test/plugin.extractKeysFromExpression.test.ts
@@ -1,0 +1,208 @@
+import { vol } from 'memfs'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import type { Expression } from '@swc/core'
+import { findKeys } from '../src/index'
+import type { I18nextToolkitConfig, Plugin, Logger } from '../src/types'
+
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+vi.mock('glob', () => ({ glob: vi.fn() }))
+
+describe('plugin system: extractKeysFromExpression', () => {
+  beforeEach(async () => {
+    vol.reset()
+    vi.clearAllMocks()
+    vi.spyOn(process, 'cwd').mockReturnValue('/')
+    const { glob } = await import('glob')
+    vi.mocked(glob).mockResolvedValue(['/src/App.tsx'])
+  })
+
+  it('should extract keys from template literals variable names using extractKeysFromExpression', async () => {
+    const sampleCode = `
+      const namespace = 'user';
+      const action = 'login';
+      t(\`\${namespace}.\${action}\`);
+      t(\`\${namespace}.state.\${action}\`);
+      t('key.literal');
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    // Create a plugin that extracts keys from template literals based on variable names
+    const templateLiteralPlugin = (): Plugin => ({
+      name: 'template-literal-extractor',
+      extractKeysFromExpression: (expression: Expression, config, logger: Logger) => {
+        const keys: string[] = []
+
+        // Handle template literals with simple variable substitutions
+        if (expression.type === 'TemplateLiteral') {
+          // For this example, we'll extract a pattern if we can determine the values
+          const joins = expression.quasis.map(quasi => quasi.cooked)
+          const parts = expression.expressions.map(expression => expression.type === 'Identifier' ? expression.value : 'unknown')
+
+          if (parts.length > 0) {
+            keys.push(joins.reduce<string>((acc, join, i) => (acc) + (join || '') + (parts[i] || ''), ''))
+          }
+        }
+
+        return keys
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [templateLiteralPlugin()],
+    }
+
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    expect(extractedKeys).toContain('key.literal')
+    expect(extractedKeys).toContain('namespace.action')
+    expect(extractedKeys).toContain('namespace.state.action')
+  })
+
+  it('should handle multiple plugins with extractKeysFromExpression', async () => {
+    const sampleCode = `
+      t(18n);
+      t(\`prefix.\${suffix}\`);
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const bigIntPlugin = (): Plugin => ({
+      name: 'big-int-plugin',
+      extractKeysFromExpression: (expression: Expression) => {
+        if (expression.type === 'BigIntLiteral') {
+          return [expression.raw || '']
+        }
+
+        return []
+      },
+    })
+
+    const templatePlugin = (): Plugin => ({
+      name: 'template-plugin',
+      extractKeysFromExpression: (expression: Expression) => {
+        if (expression.type === 'TemplateLiteral') {
+          return ['prefix.dynamic1', 'prefix.dynamic2']
+        }
+        return []
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [bigIntPlugin(), templatePlugin()],
+    }
+
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    // Both plugins should return keys
+    expect(extractedKeys).toContain('18n')
+    expect(extractedKeys).toContain('prefix.dynamic1')
+    expect(extractedKeys).toContain('prefix.dynamic2')
+  })
+
+  it('should handle errors gracefully in extractKeysFromExpression', async () => {
+    const sampleCode = `
+      t('key.normal');
+      t(someExpression);
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const faultyPlugin = (): Plugin => ({
+      name: 'faulty-plugin',
+      extractKeysFromExpression: (expression: Expression) => {
+        throw new Error('Plugin error!')
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [faultyPlugin()],
+    }
+
+    // Should not throw
+    const { allKeys } = await findKeys(config)
+    const extractedKeys = Array.from(allKeys.values()).map(k => k.key)
+
+    // Keys should still be extracted despite plugin error
+    expect(extractedKeys).toContain('key.normal')
+  })
+
+  it('should provide config and logger to extractKeysFromExpression', async () => {
+    const sampleCode = `
+      t(someVar ? 'key.test' : 'key.fallback');
+    `
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const configSpy = vi.fn()
+    const loggerSpy = vi.fn()
+
+    const inspectorPlugin = (): Plugin => ({
+      name: 'inspector-plugin',
+      extractKeysFromExpression: (expression: Expression, config, logger: Logger) => {
+        // Pass to spies to access references after the plugin is called
+        configSpy(config)
+        loggerSpy(logger)
+
+        if (expression.type === 'ConditionalExpression') {
+          const keys: string[] = []
+          if (expression.consequent.type === 'StringLiteral') {
+            keys.push(expression.consequent.value)
+          }
+          return keys
+        }
+        return []
+      },
+    })
+
+    const config: I18nextToolkitConfig = {
+      locales: ['en'],
+      extract: {
+        input: ['src/**/*.tsx'],
+        output: 'locales/{{language}}/{{namespace}}.json',
+      },
+      plugins: [inspectorPlugin()],
+    }
+
+    await findKeys(config)
+
+    // Verify that the plugin received config and logger
+    expect(configSpy).toHaveBeenCalled()
+    expect(loggerSpy).toHaveBeenCalled()
+
+    const receivedConfig = configSpy.mock.calls[0][0]
+    expect(receivedConfig).toHaveProperty('locales')
+    expect(receivedConfig).toHaveProperty('extract')
+
+    const receivedLogger = loggerSpy.mock.calls[0][0]
+    expect(receivedLogger).toHaveProperty('warn')
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

@adrai open to feedback here, this makes adding TypeScript support significantly easier and sidesteps having to pull in most of the i18next machinery for plurals, etc.

Allow plugins to export a context-less function, `extractKeysFromExpression`, which `i18next-cli` calls to parse key expressions. The function is intentionally context-less so it remains relatively "pure" (i.e. it does not depend on parsing state, AST location, etc)

This enables extensions to handle custom syntax or patterns without having to manage pluralization, etc.

`onVisitNode` can continue being used for more complex usecases, if the plugin is implementing custom attrs, etc.

#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)