### PR TITLE
Fix incorrect map value type in Plugin.onEnd keys argument

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -256,7 +256,7 @@ export interface Plugin {
    *
    * @param keys - Final map of all extracted keys
    */
-  onEnd?: (keys: Map<string, { key: string; defaultValue?: string }>) => void | Promise<void>;
+  onEnd?: (keys: Map<string, ExtractedKey>) => void | Promise<void>;
 
   /**
    * Hook called after all files have been processed and translation files have been generated.


### PR DESCRIPTION
Updated the `Plugin.onEnd` keys argument type from `Map<string, { key: string; defaultValue?: string }>` to `Map<string, ExtractedKey>` to reflect the actual type passed at runtime.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [ ] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)