### PR TITLE
feat(default-value): add value parameter to defaultValue function

### DIFF
--- a/src/syncer.ts
+++ b/src/syncer.ts
@@ -1,13 +1,13 @@
-import { writeFile, mkdir } from 'node:fs/promises'
-import { resolve, dirname, basename } from 'node:path'
 import chalk from 'chalk'
-import ora from 'ora'
 import { glob } from 'glob'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { basename, dirname, resolve } from 'node:path'
+import ora from 'ora'
 import type { I18nextToolkitConfig } from './types'
-import { getNestedKeys, getNestedValue, setNestedValue } from './utils/nested-object'
-import { getOutputPath, loadTranslationFile, serializeTranslationFile } from './utils/file-utils'
-import { shouldShowFunnel, recordFunnelShown } from './utils/funnel-msg-tracker'
 import { resolveDefaultValue } from './utils/default-value'
+import { getOutputPath, loadTranslationFile, serializeTranslationFile } from './utils/file-utils'
+import { recordFunnelShown, shouldShowFunnel } from './utils/funnel-msg-tracker'
+import { getNestedKeys, getNestedValue, setNestedValue } from './utils/nested-object'
 
 /**
  * Synchronizes translation files across different locales by ensuring all secondary
@@ -84,10 +84,11 @@ export async function runSyncer (config: I18nextToolkitConfig) {
         const newSecondaryTranslations: Record<string, any> = {}
 
         for (const key of primaryKeys) {
+          const primaryValue = getNestedValue(primaryTranslations, key, keySeparator ?? '.')
           const existingValue = getNestedValue(existingSecondaryTranslations, key, keySeparator ?? '.')
 
           // Use the resolved default value if no existing value
-          const valueToSet = existingValue ?? resolveDefaultValue(defaultValue, key, ns, lang)
+          const valueToSet = existingValue ?? resolveDefaultValue(defaultValue, key, ns, lang, primaryValue)
           setNestedValue(newSecondaryTranslations, key, valueToSet, keySeparator ?? '.')
         }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Node, Expression, ObjectExpression } from '@swc/core'
+import type { Expression, Node, ObjectExpression } from '@swc/core'
 
 /**
  * Main configuration interface for the i18next toolkit.
@@ -88,7 +88,7 @@ export interface I18nextToolkitConfig {
     indentation?: number | string;
 
     /** Default value to use for missing translations in secondary languages */
-    defaultValue?: string | ((key: string, namespace: string, language: string) => string);
+    defaultValue?: string | ((key: string, namespace: string, language: string, value: string) => string);
 
     /** Primary language that provides default values (default: first locale) */
     primaryLanguage?: string;

--- a/src/utils/default-value.ts
+++ b/src/utils/default-value.ts
@@ -11,29 +11,30 @@
  * @example
  * ```typescript
  * // String-based default value
- * const result1 = resolveDefaultValue('[MISSING]', 'user.name', 'common', 'de')
+ * const result1 = resolveDefaultValue('[MISSING]', 'user.name', 'common', 'de', 'Alice')
  * // Returns: '[MISSING]'
  *
  * // Function-based default value
  * const defaultValueFn = (key, ns, lang) => `${lang.toUpperCase()}_${ns}_${key}`
- * const result2 = resolveDefaultValue(defaultValueFn, 'user.name', 'common', 'de')
- * // Returns: 'DE_common_user.name'
+ * const result2 = resolveDefaultValue(defaultValueFn, 'user.name', 'common', 'de', 'Alice')
+ * // Returns: 'DE_common_user.name_Alice'
  *
  * // Error handling - function throws
  * const errorFn = () => { throw new Error('Oops') }
- * const result3 = resolveDefaultValue(errorFn, 'user.name', 'common', 'de')
+ * const result3 = resolveDefaultValue(errorFn, 'user.name', 'common', 'de', 'Alice')
  * // Returns: '' (fallback to empty string)
  * ```
  */
 export function resolveDefaultValue (
-  defaultValue: string | ((key: string, namespace: string, language: string) => string) | undefined,
+  defaultValue: string | ((key: string, namespace: string, language: string, value: string) => string) | undefined,
   key: string,
   namespace: string,
-  language: string
+  language: string,
+  value: string
 ): string {
   if (typeof defaultValue === 'function') {
     try {
-      return defaultValue(key, namespace, language)
+      return defaultValue(key, namespace, language, value)
     } catch (error) {
       // If the function throws an error, fall back to empty string
       return ''

--- a/test/syncer.test.ts
+++ b/test/syncer.test.ts
@@ -1,8 +1,8 @@
 import { vol } from 'memfs'
-import { vi, describe, it, expect, beforeEach } from 'vitest'
-import { runSyncer } from '../src/index'
-import type { I18nextToolkitConfig } from '../src/index'
 import { resolve } from 'path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { I18nextToolkitConfig } from '../src/index'
+import { runSyncer } from '../src/index'
 
 vi.mock('fs/promises', async () => {
   const memfs = await vi.importActual<typeof import('memfs')>('memfs')
@@ -126,8 +126,8 @@ describe('syncer', () => {
       ...mockConfig,
       extract: {
         ...mockConfig.extract,
-        defaultValue: (key: string, namespace: string, language: string) => {
-          return `${language.toUpperCase()}_${namespace}_${key}`
+        defaultValue: (key: string, namespace: string, language: string, value: string) => {
+          return `${language.toUpperCase()}_${namespace}_${key}_${value}`
         },
       },
     }
@@ -145,10 +145,10 @@ describe('syncer', () => {
     expect(updatedDeJson).toEqual({
       user: {
         name: 'Name', // Preserved existing value
-        email: 'DE_translation_user.email', // Function-generated default
+        email: 'DE_translation_user.email_Email', // Function-generated default
       },
       settings: {
-        theme: 'DE_translation_settings.theme', // Function-generated default
+        theme: 'DE_translation_settings.theme_Theme', // Function-generated default
       },
     })
   })


### PR DESCRIPTION
Allow defaultValue function to access the primary translation value when generating fallback translations. This provides convenience for automated translation scenarios.

Update tests and documentation to reflect the new parameter. 

Reorder imports. (This is something my VSCode plugin automatically does when I save; if you don't need it, I can adjust it back :))

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)