### PR TITLE
Parse simple template strings when extracting defaultValue-s

### DIFF
--- a/src/extractor/parsers/ast-utils.ts
+++ b/src/extractor/parsers/ast-utils.ts
@@ -1,4 +1,4 @@
-import type { ObjectExpression } from '@swc/core'
+import type { ObjectExpression, TemplateLiteral } from '@swc/core'
 
 /**
  * Finds and returns the full property node (KeyValueProperty) for the given
@@ -28,6 +28,18 @@ export function getObjectProperty (object: ObjectExpression, propName: string) {
 }
 
 /**
+ * Checks if the given template literal has no interpolation expressions
+ *
+ * @param literal - Template literal to check
+ * @returns Boolean true if the literal has no expressions and can be parsed (no invalid escapes), false otherwise
+ *
+ * @private
+ */
+export function isSimpleTemplateLiteral (literal: TemplateLiteral): boolean {
+  return literal.quasis.length === 1 && literal.expressions.length === 0 && literal.quasis[0].cooked != null
+}
+
+/**
  * Extracts string value from object property.
  *
  * Looks for properties by name and returns their string values.
@@ -45,6 +57,7 @@ export function getObjectPropValue (object: ObjectExpression, propName: string):
   if (prop?.type === 'KeyValueProperty') {
     const val = prop.value
     if (val.type === 'StringLiteral') return val.value
+    if (val.type === 'TemplateLiteral' && isSimpleTemplateLiteral(val)) return val.quasis[0].cooked
     if (val.type === 'BooleanLiteral') return val.value
     if (val.type === 'NumericLiteral') return val.value
     return '' // Indicate presence for other types

--- a/src/extractor/parsers/call-expression-handler.ts
+++ b/src/extractor/parsers/call-expression-handler.ts
@@ -1,7 +1,7 @@
 import type { CallExpression, ArrowFunctionExpression, ObjectExpression } from '@swc/core'
 import type { PluginContext, I18nextToolkitConfig, Logger, ExtractedKey, ScopeInfo } from '../../types'
 import { ExpressionResolver } from './expression-resolver'
-import { getObjectProperty, getObjectPropValue } from './ast-utils'
+import { getObjectProperty, getObjectPropValue, isSimpleTemplateLiteral } from './ast-utils'
 
 export class CallExpressionHandler {
   private pluginContext: PluginContext
@@ -87,6 +87,8 @@ export class CallExpressionHandler {
         options = arg2
       } else if (arg2.type === 'StringLiteral') {
         defaultValue = arg2.value
+      } else if (arg2.type === 'TemplateLiteral' && isSimpleTemplateLiteral(arg2)) {
+        defaultValue = arg2.quasis[0].cooked
       }
     }
     if (node.arguments.length > 2) {

--- a/test/extractor.runExtractor.test.ts
+++ b/test/extractor.runExtractor.test.ts
@@ -1664,4 +1664,26 @@ describe('extractor: runExtractor', () => {
       // The commented keys matching preservePatterns were NOT extracted (correct behavior)
     })
   })
+
+  it('should parse simple template literals as default values', async () => {
+    const sampleCode = `
+      t('app.title', { defaultValue: \`Welcome!\` });
+      t('app.subtitle', \`Glad to meet you!\`);
+    `
+
+    vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+    await runExtractor(mockConfig)
+
+    const translationPath = resolve(process.cwd(), 'locales/en/translation.json')
+    const translationFileContent = await vol.promises.readFile(translationPath, 'utf-8')
+    const translationJson = JSON.parse(translationFileContent as string)
+
+    expect(translationJson).toEqual({
+      app: {
+        title: 'Welcome!',
+        subtitle: 'Glad to meet you!',
+      },
+    })
+  })
 })


### PR DESCRIPTION
Hi! This adds support for extracting defaultValues that use simple template strings, without interpolated expressions. This is often used when writing multi-line strings or to avoid escaping quotes. With this PR, i18next-cli should successfully extract cases like the following:

```tsx
t("key", `Some "quoted" text!`)
t("key", `A
  multiline string`);
t("key", { defaultValue: `Template string in opts object default` })
<Trans>{`Template string in Trans child`}</Trans>
<Trans defaults={`Template string in Trans explicit default`} />
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x ] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)