### PR TITLE
Fix preservingContextVariants when using shorthand property for context in options.

### DIFF
--- a/src/extractor/parsers/ast-utils.ts
+++ b/src/extractor/parsers/ast-utils.ts
@@ -1,4 +1,4 @@
-import type { ObjectExpression, TemplateLiteral } from '@swc/core'
+import type { Expression, Identifier, ObjectExpression, TemplateLiteral } from '@swc/core'
 
 /**
  * Finds and returns the full property node (KeyValueProperty) for the given
@@ -25,6 +25,27 @@ export function getObjectProperty (object: ObjectExpression, propName: string) {
           (p.key?.type === 'StringLiteral' && p.key.value === propName)
         )
     )
+}
+
+/**
+ * Finds and returns the value node for the given property name from an ObjectExpression.
+ *
+ * Matches both identifier keys (e.g., { ns: 'value' }), string literal keys
+ * (e.g., { 'ns': 'value' }) and shorthand properties (e.g., { ns }).
+ *
+ * This helper returns the full value node rather than just its primitive
+ * value so callers can inspect expression types (ConditionalExpression, etc.).
+ *
+ * @private
+ * @param object - The SWC ObjectExpression to search
+ * @param propName - The property name to locate
+ * @returns The matching value node if found, otherwise undefined.
+ */
+export function getObjectPropValueExpression (object: ObjectExpression, propName: string): Expression | undefined {
+  return getObjectProperty(object, propName)?.value ?? (object.properties).find(
+    // For shorthand properties like { ns }.
+    (p): p is Identifier => p.type === 'Identifier' && p.value === propName
+  )
 }
 
 /**

--- a/src/extractor/parsers/call-expression-handler.ts
+++ b/src/extractor/parsers/call-expression-handler.ts
@@ -1,7 +1,7 @@
 import type { CallExpression, ArrowFunctionExpression, ObjectExpression } from '@swc/core'
 import type { PluginContext, I18nextToolkitConfig, Logger, ExtractedKey, ScopeInfo } from '../../types'
 import { ExpressionResolver } from './expression-resolver'
-import { getObjectProperty, getObjectPropValue, isSimpleTemplateLiteral } from './ast-utils'
+import { getObjectPropValueExpression, getObjectPropValue, isSimpleTemplateLiteral } from './ast-utils'
 
 export class CallExpressionHandler {
   private pluginContext: PluginContext
@@ -210,22 +210,22 @@ export class CallExpressionHandler {
 
       // Handle plurals, context, and returnObjects
       if (options) {
-        const contextProp = getObjectProperty(options, 'context')
+        const contextPropValue = getObjectPropValueExpression(options, 'context')
 
         const keysWithContext: ExtractedKey[] = []
 
         // 1. Handle Context
-        if (contextProp?.value?.type === 'StringLiteral' || contextProp?.value.type === 'NumericLiteral' || contextProp?.value.type === 'BooleanLiteral') {
+        if (contextPropValue?.type === 'StringLiteral' || contextPropValue?.type === 'NumericLiteral' || contextPropValue?.type === 'BooleanLiteral') {
           // If the context is static, we don't need to add the base key
-          const contextValue = `${contextProp.value.value}`
+          const contextValue = `${contextPropValue.value}`
 
           const contextSeparator = this.config.extract.contextSeparator ?? '_'
           // Ignore context: ''
           if (contextValue !== '') {
             keysWithContext.push({ key: `${finalKey}${contextSeparator}${contextValue}`, ns, defaultValue: dv, explicitDefault: explicitDefaultForBase })
           }
-        } else if (contextProp?.value) {
-          const contextValues = this.expressionResolver.resolvePossibleContextStringValues(contextProp.value)
+        } else if (contextPropValue) {
+          const contextValues = this.expressionResolver.resolvePossibleContextStringValues(contextPropValue)
           const contextSeparator = this.config.extract.contextSeparator ?? '_'
 
           if (contextValues.length > 0) {
@@ -551,16 +551,16 @@ export class CallExpressionHandler {
       const ordinalOtherDefault = getObjectPropValue(options, `defaultValue${pluralSeparator}ordinal${pluralSeparator}other`)
 
       // Handle context - both static and dynamic
-      const contextProp = getObjectProperty(options, 'context')
+      const contextPropValue = getObjectPropValueExpression(options, 'context')
       const keysToGenerate: Array<{ key: string, context?: string }> = []
 
-      if (contextProp?.value) {
+      if (contextPropValue) {
         // Handle dynamic context by resolving all possible values
-        const contextValues = this.expressionResolver.resolvePossibleContextStringValues(contextProp.value)
+        const contextValues = this.expressionResolver.resolvePossibleContextStringValues(contextPropValue)
 
         if (contextValues.length > 0) {
           // For static context (string literal), only generate context variants
-          if (contextProp.value.type === 'StringLiteral') {
+          if (contextPropValue.type === 'StringLiteral') {
             // Only generate context-specific plural forms, no base forms
             for (const contextValue of contextValues) {
               if (contextValue.length > 0) {

--- a/src/extractor/parsers/jsx-parser.ts
+++ b/src/extractor/parsers/jsx-parser.ts
@@ -1,6 +1,6 @@
-import type { Expression, JSXAttribute, JSXElement, JSXExpression, ObjectExpression, Property } from '@swc/core'
+import type { Expression, JSXAttribute, JSXElement, JSXExpression, ObjectExpression } from '@swc/core'
 import type { I18nextToolkitConfig } from '../../types'
-import { getObjectProperty, getObjectPropValue, isSimpleTemplateLiteral } from './ast-utils'
+import { getObjectPropValue, getObjectPropValueExpression, isSimpleTemplateLiteral } from './ast-utils'
 
 export interface ExtractedJSXAttributes {
   /** holds the raw key expression from the AST */
@@ -116,14 +116,14 @@ export function extractFromTransComponent (node: JSXElement, config: I18nextTool
   )
 
   // Find the 'count' property in the 'values' object if count={...} is not defined
-  let valuesCountProperty: Property | undefined
+  let valuesCountProperty: Expression | undefined
   if (
     !countAttr &&
     valuesAttr?.type === 'JSXAttribute' &&
     valuesAttr.value?.type === 'JSXExpressionContainer' &&
     valuesAttr.value.expression.type === 'ObjectExpression'
   ) {
-    valuesCountProperty = getObjectProperty(valuesAttr.value.expression, 'count')
+    valuesCountProperty = getObjectPropValueExpression(valuesAttr.value.expression, 'count')
   }
 
   const hasCount = !!countAttr || !!valuesCountProperty
@@ -174,10 +174,7 @@ export function extractFromTransComponent (node: JSXElement, config: I18nextTool
       ns = getObjectPropValue(optionsNode, 'ns') as string | undefined
     }
     if (contextExpression === undefined) {
-      const contextPropFromOptions = getObjectProperty(optionsNode, 'context')
-      if (contextPropFromOptions?.value) {
-        contextExpression = contextPropFromOptions.value
-      }
+      contextExpression = getObjectPropValueExpression(optionsNode, 'context')
     }
   }
 


### PR DESCRIPTION
#### Checklist

- [X] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
