### PR TITLE
fix: patch glob sec vuln

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "chokidar": "4.0.3",
     "commander": "14.0.2",
     "execa": "9.6.0",
-    "glob": "11.0.3",
+    "glob": "12.0.0",
     "i18next-resources-for-ts": "1.8.0",
     "inquirer": "12.10.0",
     "jiti": "2.6.1",


### PR DESCRIPTION
`glob` v11.0.3 has the following high severity security vulnerability: [GHSA-5j98-mcp5-4vw2](https://github.com/isaacs/node-glob/security/advisories/GHSA-5j98-mcp5-4vw2), which is patched in v12.
The breaking changes in v12 ([CHANGELOG](https://github.com/isaacs/node-glob/blob/main/changelog.md#12)) do not affect this project.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)