### PR TITLE
feat(status): Add CI flag to exit when locales have missing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,10 @@ npx i18next-cli extract --sync-primary --watch
 
 ### `status [locale]`
 
-Displays a health check of your project's translation status. Can run without a config file.
+Displays a health check of your project's translation status. Can run without a config file. Exits with a non-zero status code when translations are missing.
 
 **Options:**
 - `--namespace <ns>, -n <ns>`: Filter the report by a specific namespace.
-- `--ci`: Exit with a non-zero status code if there are missing translations.
 
 **Usage Examples:**
 
@@ -158,9 +157,6 @@ npx i18next-cli status --namespace common
 
 # Get a detailed report for the 'de' locale, showing only the 'common' namespace
 npx i18next-cli status de --namespace common
-
-# Exit with a non-zero status code when there are missing translations (useful for CI)
-npx i18next-cli status --ci
 ```
 
 The detailed view provides a rich, at-a-glance summary for each namespace, followed by a list of every key and its translation status.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,7 +96,6 @@ program
   .command('status [locale]')
   .description('Display translation status. Provide a locale for a detailed key-by-key view.')
   .option('-n, --namespace <ns>', 'Filter the status report by a specific namespace')
-  .option('--ci', 'Exit with a non-zero status code if there are missing translations')
   .action(async (locale, options) => {
     const cfgPath = program.opts().config
     let config = await loadConfig(cfgPath)
@@ -111,7 +110,7 @@ program
       console.log(chalk.green('Project structure detected successfully!'))
       config = detected as I18nextToolkitConfig
     }
-    await runStatus(config, { detail: locale, namespace: options.namespace, ci: options.ci })
+    await runStatus(config, { detail: locale, namespace: options.namespace })
   })
 
 program

--- a/src/status.ts
+++ b/src/status.ts
@@ -15,8 +15,6 @@ interface StatusOptions {
   detail?: string;
   /** Namespace to filter the report by */
   namespace?: string;
-  /** Exit with a non-zero status code if there are missing translations */
-  ci?: boolean;
 }
 
 /**
@@ -67,18 +65,16 @@ export async function runStatus (config: I18nextToolkitConfig, options: StatusOp
     const report = await generateStatusReport(config)
     spinner.succeed('Analysis complete.')
     await displayStatusReport(report, config, options)
-    if (options.ci) {
-      let hasMissing = false
-      for (const [, localeData] of report.locales.entries()) {
-        if (localeData.totalTranslated < report.totalBaseKeys) {
-          hasMissing = true
-          break
-        }
+    let hasMissing = false
+    for (const [, localeData] of report.locales.entries()) {
+      if (localeData.totalTranslated < report.totalBaseKeys) {
+        hasMissing = true
+        break
       }
-      if (hasMissing) {
-        spinner.fail('Error: Missing translations detected. Failing due to CI mode.')
-        process.exit(1)
-      }
+    }
+    if (hasMissing) {
+      spinner.fail('Error: Missing translations detected.')
+      process.exit(1)
     }
   } catch (error) {
     spinner.fail('Failed to generate status report.')


### PR DESCRIPTION
This pull request adds support for a "CI mode" to the `i18next-cli status` command, enabling automated detection of missing translations in continuous integration environments. When the new `ci` option is enabled, the process will exit with a non-zero status code if any missing translations are detected.