### PR TITLE
improve jsx parser to ignore jsx comments

### DIFF
--- a/src/extractor/parsers/jsx-parser.ts
+++ b/src/extractor/parsers/jsx-parser.ts
@@ -904,8 +904,10 @@ function serializeJSXChildren (children: any[], config: I18nextToolkitConfig): s
           out += `{{${expr.property.value}}}`
         } else if (expr.type === 'CallExpression' && expr.callee?.type === 'Identifier') {
           out += `{{${expr.callee.value}}}`
+        } else if (expr.type === 'JSXEmptyExpression') {
+          // skip
         } else {
-          throw new Error('Unrecognized expression in JSX placeholder')
+          throw new Error(`Unrecognized expression in JSX placeholder: ${expr.type}`)
         }
         continue
       }

--- a/test/extractor.Trans.test.ts
+++ b/test/extractor.Trans.test.ts
@@ -509,6 +509,32 @@ describe('extractor: advanced Trans features', () => {
     })
   })
 
+  it('should handle comments', async () => {
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function Component() {
+        const { t } = useTranslation();
+
+        return (
+          <Trans t={t} i18nKey='SomeKey'>
+            Some content
+            {/* Hidden comment */}
+          </Trans>
+        );
+      }
+    `
+    vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+    const results = await extract(mockConfig)
+    const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/translation.json'))
+
+    expect(translationFile).toBeDefined()
+    expect(translationFile!.newTranslations).toEqual({
+      SomeKey: 'Some content',
+    })
+  })
+
   it('should NOT extract space between text and component when separated by newline (formatting)', async () => {
     const sampleCode = `
       import { useTranslation } from 'react-i18next';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Since v1.29.1 the jsx-parser would choke on comments in `<Trans>` and raise an error

```tsx
<Trans t={t} i18nKey='SomeKey'>
    Some content
    {/* Hidden comment */}
</Trans>
```

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [X] run tests `npm run test`
- [X] tests are included
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
