### PR TITLE
Allow extraction from `new` expressions

### DIFF
--- a/src/extractor/core/ast-visitors.ts
+++ b/src/extractor/core/ast-visitors.ts
@@ -261,6 +261,16 @@ export class ASTVisitors {
       case 'CallExpression':
         this.callExpressionHandler.handleCallExpression(node, this.scopeManager.getVarFromScope.bind(this.scopeManager))
         break
+      case 'NewExpression':
+        // Handle NewExpression similarly to CallExpression (e.g., new TranslatedError(...))
+        // NewExpression has the same structure: callee and arguments
+        this.callExpressionHandler.handleCallExpression({
+          ...node,
+          arguments: node.arguments || []
+        },
+        this.scopeManager.getVarFromScope.bind(this.scopeManager)
+        )
+        break
       case 'JSXElement':
         this.jsxHandler.handleJSXElement(node, this.scopeManager.getVarFromScope.bind(this.scopeManager))
         break

--- a/src/extractor/parsers/call-expression-handler.ts
+++ b/src/extractor/parsers/call-expression-handler.ts
@@ -48,10 +48,10 @@ export class CallExpressionHandler {
     const code = this.getCurrentCode()
 
     // Extract searchable text from the node
-    // For CallExpression, we can search for the key argument
+    // For CallExpression and NewExpression, we can search for the key argument
     let searchText: string | undefined
 
-    if (node.type === 'CallExpression' && node.arguments.length > 0) {
+    if ((node.type === 'CallExpression' || node.type === 'NewExpression') && node.arguments.length > 0) {
       const firstArg = node.arguments[0].expression
 
       if (firstArg.type === 'StringLiteral') {
@@ -89,17 +89,18 @@ export class CallExpressionHandler {
   }
 
   /**
-   * Processes function call expressions to extract translation keys.
+   * Processes function call expressions and new expressions to extract translation keys.
    *
    * This is the core extraction method that handles:
    * - Standard t() calls with string literals
+   * - NewExpression calls like new TranslatedError(...)
    * - Selector API calls with arrow functions: `t($ => $.path.to.key)`
    * - Namespace resolution from multiple sources
    * - Default value extraction from various argument patterns
    * - Pluralization and context handling
    * - Key prefix application from scope
    *
-   * @param node - Call expression node to process
+   * @param node - Call expression or new expression node to process
    * @param getScopeInfo - Function to retrieve scope information for variables
    */
   handleCallExpression (node: CallExpression, getScopeInfo: (name: string) => ScopeInfo | undefined): void {

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -1744,6 +1744,32 @@ describe('extractor: advanced t features', () => {
 }`)
   })
 
+  it('should extract keys from NewExpression (e.g., new TranslatedError())', async () => {
+    const sampleCode = `
+      new TranslatedError('error.notFound', 'Not found');
+      new TranslatedError('error.unauthorized', 'Unauthorized');
+    `
+    vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+    const customConfig: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        keySeparator: false,
+        functions: ['t', 'TranslatedError'],
+      },
+    }
+
+    const results = await extract(customConfig)
+    const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/translation.json'))
+
+    expect(translationFile).toBeDefined()
+    expect(translationFile!.newTranslations).toEqual({
+      'error.notFound': 'Not found',
+      'error.unauthorized': 'Unauthorized',
+    })
+  })
+
   describe('colons in value', () => {
     it('should correctly extract fallback values containing colons', async () => {
       const sampleCode = `


### PR DESCRIPTION
This allows extracting translations from constructors as well
i take the example that i use it for in the test, we have a `TranslatedError` class that would be nice to use like that

I understand this is a bit niche, but it would be nice to have

Thank you for creating this, it's been highly useful and i really like being able to keep the text in-line where it's used rather than refering to a separate "translation-strings" file. We're working 100% with extracted strings at the moment. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [ ] only relevant documentation part is changed (make a diff before you submit the PR)
- [ ] motivation/reason is provided
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)