### PR TITLE
add support for ignoring namespaces during extraction, status, and sync operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,11 @@ export default defineConfig({
     /** If true, keys that are not found in the source code will be removed from translation files. (default: true) */
     removeUnusedKeys: true,
 
+    // Namespaces to ignore during extraction, status, and sync operations.
+    // Useful for monorepos where shared namespaces are managed elsewhere.
+    // Keys using these namespaces will be excluded from processing.
+    ignoreNamespaces?: ['shared', 'common'], // Optional
+
     // When true (default), the extractor also scans code comments for t(...) / Trans examples and will extract keys found there.
     // Set to false to ignore translation-like patterns in comments (useful to avoid extracting example/documentation strings).
     extractFromComments: true,

--- a/src/extractor/core/translation-manager.ts
+++ b/src/extractor/core/translation-manager.ts
@@ -782,6 +782,12 @@ export async function getTranslations (
     }
   }
 
+  // Filter out ignored namespaces
+  const ignoreNamespaces = new Set(config.extract.ignoreNamespaces ?? [])
+  for (const ns of ignoreNamespaces) {
+    keysByNS.delete(ns)
+  }
+
   const results: TranslationResult[] = []
   const userIgnore = Array.isArray(config.extract.ignore)
     ? config.extract.ignore

--- a/src/status.ts
+++ b/src/status.ts
@@ -109,9 +109,21 @@ async function generateStatusReport (config: I18nextToolkitConfig): Promise<Stat
     if (!keysByNs.has(ns)) keysByNs.set(ns, [])
     keysByNs.get(ns)!.push(key)
   }
+  
+  // Filter out ignored namespaces
+  const ignoreNamespaces = new Set(config.extract.ignoreNamespaces ?? [])
+  for (const ns of ignoreNamespaces) {
+    keysByNs.delete(ns)
+  }
+
+  // Count total keys after filtering
+  let filteredKeyCount = 0
+  for (const keys of keysByNs.values()) {
+    filteredKeyCount += keys.length
+  }
 
   const report: StatusReport = {
-    totalBaseKeys: allExtractedKeys.size,
+    totalBaseKeys: filteredKeyCount,
     keysByNs,
     locales: new Map(),
   }

--- a/src/syncer.ts
+++ b/src/syncer.ts
@@ -75,9 +75,14 @@ export async function runSyncer (
       return
     }
 
+    // Filter out ignored namespaces
+    const ignoreNamespaces = new Set(config.extract.ignoreNamespaces ?? [])
+
     // 2. Loop through each primary namespace file
     for (const primaryPath of primaryNsFiles) {
       const ns = basename(primaryPath).split('.')[0]
+      // Skip ignored namespaces
+      if (ignoreNamespaces.has(ns)) continue
       const primaryTranslations = await loadTranslationFile(primaryPath)
 
       if (!primaryTranslations) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,14 @@ export interface I18nextToolkitConfig {
     removeUnusedKeys?: boolean;
 
     /**
+     * Array of namespace names to ignore during extraction, status, and sync operations.
+     * Keys using these namespaces will be excluded from processing.
+     * Useful for monorepos where shared namespaces are managed elsewhere.
+     * @example ['shared', 'common']
+     */
+    ignoreNamespaces?: string[];
+
+    /**
      * If false, translation keys will not be extracted from comments.
      * (default: true)
      */

--- a/test/extractor.ignoreNamespaces.test.ts
+++ b/test/extractor.ignoreNamespaces.test.ts
@@ -1,0 +1,277 @@
+import { vol } from 'memfs'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { runExtractor } from '../src/index'
+import type { I18nextToolkitConfig } from '../src/index'
+import { resolve } from 'path'
+
+// Mock the 'fs/promises' module to use our in-memory file system from 'memfs'
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+
+// Mock the 'glob' module to control which files it "finds"
+vi.mock('glob', () => ({
+  glob: vi.fn(),
+}))
+
+const mockConfig: I18nextToolkitConfig = {
+  locales: ['en', 'de'],
+  extract: {
+    input: ['src/**/*.{ts,tsx}'],
+    output: 'locales/{{language}}/{{namespace}}.json',
+    functions: ['t'],
+    transComponents: ['Trans'],
+    defaultNS: 'translation',
+  },
+}
+
+describe('extractor: ignoreNamespaces', () => {
+  beforeEach(async () => {
+    vol.reset()
+    vi.clearAllMocks()
+
+    // Mock the current working directory to align with the virtual file system's root.
+    vi.spyOn(process, 'cwd').mockReturnValue('/')
+
+    // Dynamically import the mocked glob after mocks are set up
+    const { glob } = await import('glob')
+    vi.mocked(glob).mockImplementation(async () => {
+      // Return any files that exist in memfs under /src/
+      return Object.keys(vol.toJSON()).filter(p => p.includes('/src/'))
+    })
+  })
+
+  it('should not extract keys from ignored namespaces', async () => {
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function App() {
+        const { t } = useTranslation();
+        const { t: tShared } = useTranslation('shared');
+        return (
+          <div>
+            <h1>{t('local.title')}</h1>
+            <p>{tShared('shared.message')}</p>
+          </div>
+        );
+      }
+    `
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared'],
+      },
+    }
+
+    await runExtractor(config)
+
+    const enLocalPath = resolve(process.cwd(), 'locales/en/translation.json')
+    const enSharedPath = resolve(process.cwd(), 'locales/en/shared.json')
+
+    // Local namespace should be created with keys
+    const enLocalContent = await vol.promises.readFile(enLocalPath, 'utf-8')
+    const enLocalJson = JSON.parse(enLocalContent as string)
+    expect(enLocalJson).toHaveProperty('local.title')
+
+    // Shared namespace should NOT be created
+    expect(vol.existsSync(enSharedPath)).toBe(false)
+  })
+
+  it('should not extract keys with explicit namespace prefix when namespace is ignored', async () => {
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function App() {
+        const { t } = useTranslation();
+        return (
+          <div>
+            <h1>{t('local.title')}</h1>
+            <p>{t('common:shared.button')}</p>
+          </div>
+        );
+      }
+    `
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['common'],
+      },
+    }
+
+    await runExtractor(config)
+
+    const enLocalPath = resolve(process.cwd(), 'locales/en/translation.json')
+    const enCommonPath = resolve(process.cwd(), 'locales/en/common.json')
+
+    // Local namespace should be created with local.title
+    const enLocalContent = await vol.promises.readFile(enLocalPath, 'utf-8')
+    const enLocalJson = JSON.parse(enLocalContent as string)
+    expect(enLocalJson).toHaveProperty('local.title')
+
+    // Common namespace should NOT be created
+    expect(vol.existsSync(enCommonPath)).toBe(false)
+  })
+
+  it('should ignore multiple namespaces', async () => {
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function App() {
+        const { t } = useTranslation();
+        const { t: tShared } = useTranslation('shared');
+        const { t: tCommon } = useTranslation('common');
+        return (
+          <div>
+            <h1>{t('app.title')}</h1>
+            <p>{tShared('shared.message')}</p>
+            <button>{tCommon('common.save')}</button>
+          </div>
+        );
+      }
+    `
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared', 'common'],
+      },
+    }
+
+    await runExtractor(config)
+
+    const enLocalPath = resolve(process.cwd(), 'locales/en/translation.json')
+    const enSharedPath = resolve(process.cwd(), 'locales/en/shared.json')
+    const enCommonPath = resolve(process.cwd(), 'locales/en/common.json')
+
+    // Local namespace should be created with app.title
+    const enLocalContent = await vol.promises.readFile(enLocalPath, 'utf-8')
+    const enLocalJson = JSON.parse(enLocalContent as string)
+    expect(enLocalJson).toHaveProperty('app.title')
+
+    // Shared and common namespaces should NOT be created
+    expect(vol.existsSync(enSharedPath)).toBe(false)
+    expect(vol.existsSync(enCommonPath)).toBe(false)
+  })
+
+  it('should extract all namespaces when ignoreNamespaces is empty', async () => {
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function App() {
+        const { t } = useTranslation();
+        const { t: tShared } = useTranslation('shared');
+        return (
+          <div>
+            <h1>{t('local.title')}</h1>
+            <p>{tShared('shared.message')}</p>
+          </div>
+        );
+      }
+    `
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: [],
+      },
+    }
+
+    await runExtractor(config)
+
+    const enLocalPath = resolve(process.cwd(), 'locales/en/translation.json')
+    const enSharedPath = resolve(process.cwd(), 'locales/en/shared.json')
+
+    // Both namespaces should be created
+    expect(vol.existsSync(enLocalPath)).toBe(true)
+    expect(vol.existsSync(enSharedPath)).toBe(true)
+  })
+
+  it('should extract all namespaces when ignoreNamespaces is not specified', async () => {
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function App() {
+        const { t } = useTranslation();
+        const { t: tShared } = useTranslation('shared');
+        return (
+          <div>
+            <h1>{t('local.title')}</h1>
+            <p>{tShared('shared.message')}</p>
+          </div>
+        );
+      }
+    `
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+    })
+
+    await runExtractor(mockConfig)
+
+    const enLocalPath = resolve(process.cwd(), 'locales/en/translation.json')
+    const enSharedPath = resolve(process.cwd(), 'locales/en/shared.json')
+
+    // Both namespaces should be created
+    expect(vol.existsSync(enLocalPath)).toBe(true)
+    expect(vol.existsSync(enSharedPath)).toBe(true)
+  })
+
+  it('should not modify existing files for ignored namespaces', async () => {
+    const sampleCode = `
+      import { useTranslation } from 'react-i18next';
+
+      function App() {
+        const { t } = useTranslation();
+        const { t: tShared } = useTranslation('shared');
+        return (
+          <div>
+            <h1>{t('local.newKey')}</h1>
+            <p>{tShared('shared.newKey')}</p>
+          </div>
+        );
+      }
+    `
+
+    const existingSharedContent = { existing: { key: 'value' } }
+
+    vol.fromJSON({
+      '/src/App.tsx': sampleCode,
+      '/locales/en/shared.json': JSON.stringify(existingSharedContent),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared'],
+      },
+    }
+
+    await runExtractor(config)
+
+    const enSharedPath = resolve(process.cwd(), 'locales/en/shared.json')
+
+    // Shared namespace file should remain unchanged
+    const enSharedContent = await vol.promises.readFile(enSharedPath, 'utf-8')
+    const enSharedJson = JSON.parse(enSharedContent as string)
+    expect(enSharedJson).toEqual(existingSharedContent)
+  })
+})

--- a/test/status.ignoreNamespaces.test.ts
+++ b/test/status.ignoreNamespaces.test.ts
@@ -1,0 +1,245 @@
+import { vol } from 'memfs'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { resolve } from 'path'
+import type { I18nextToolkitConfig } from '../src/index'
+
+// Mock filesystem used by extractor (both sync and promises layers)
+vi.mock('fs', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs
+})
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+
+// Mock glob so extractor only scans test files we create in memfs
+vi.mock('glob', () => ({ glob: vi.fn() }))
+
+// Import runStatus AFTER mocks so internal modules use the mocked fs/glob
+const { runStatus } = await import('../src/index')
+
+const mockConfig: I18nextToolkitConfig = {
+  locales: ['en', 'de', 'fr'],
+  extract: {
+    input: ['src/**/*.{ts,tsx}'],
+    output: 'locales/{{language}}/{{namespace}}.json',
+  },
+}
+
+describe('status: ignoreNamespaces', () => {
+  let consoleLogSpy: any
+  let processExitSpy: any
+
+  beforeEach(async () => {
+    vol.reset()
+    vi.clearAllMocks()
+    // provide deterministic glob results: return only files we create in this test's memfs
+    const { glob } = await import('glob')
+    vi.mocked(glob).mockImplementation(async () => {
+      // Return any memfs path that contains a /src/ segment
+      return Object.keys(vol.toJSON()).filter(p => p.includes('/src/'))
+    })
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('Process exit called')
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should exclude ignored namespaces from status report', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app.ts')]: `
+        import { useTranslation } from 'react-i18next'
+        const { t } = useTranslation()
+        const { t: tShared } = useTranslation('shared')
+        t('local.key1')
+        t('local.key2')
+        tShared('shared.key1')
+        tShared('shared.key2')
+      `,
+      // Only local namespace translations exist
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        local: { key1: 'Schlüssel 1', key2: 'Schlüssel 2' },
+      }),
+      [resolve(process.cwd(), 'locales/fr/translation.json')]: JSON.stringify({
+        local: { key1: 'Clé 1' },
+      }),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared'],
+      },
+    }
+
+    try {
+      await runStatus(config)
+    } catch (e) {
+      // Expected to throw when process.exit is called
+    }
+
+    // Should only report 2 keys (from local namespace), not 4
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('🔑 Keys Found:         2'))
+    // Should only report 1 namespace (translation, not shared)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('📚 Namespaces Found:   1'))
+    // de should be 100% (2/2)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('100% (2/2'))
+    // fr should be 50% (1/2)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('50% (1/2'))
+  })
+
+  it('should ignore multiple namespaces in status report', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app.ts')]: `
+        import { useTranslation } from 'react-i18next'
+        const { t } = useTranslation()
+        const { t: tShared } = useTranslation('shared')
+        const { t: tCommon } = useTranslation('common')
+        t('local.key1')
+        tShared('shared.key1')
+        tCommon('common.key1')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        local: { key1: 'Schlüssel 1' },
+      }),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared', 'common'],
+      },
+    }
+
+    try {
+      await runStatus(config)
+    } catch (e) {
+      // Expected to throw when process.exit is called
+    }
+
+    // Should only report 1 key (from local namespace)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('🔑 Keys Found:         1'))
+    // Should report 1 namespace (translation only)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('📚 Namespaces Found:   1'))
+    // de should be 100% (1/1)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('100% (1/1'))
+  })
+
+  it('should report all namespaces when ignoreNamespaces is empty', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app.ts')]: `
+        import { useTranslation } from 'react-i18next'
+        const { t } = useTranslation()
+        const { t: tShared } = useTranslation('shared')
+        t('local.key1')
+        tShared('shared.key1')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        local: { key1: 'Schlüssel 1' },
+      }),
+      [resolve(process.cwd(), 'locales/de/shared.json')]: JSON.stringify({
+        shared: { key1: 'Geteilt 1' },
+      }),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: [],
+      },
+    }
+
+    try {
+      await runStatus(config)
+    } catch (e) {
+      // Expected to throw when process.exit is called
+    }
+
+    // Should report 2 keys total
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('🔑 Keys Found:         2'))
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('📚 Namespaces Found:   2'))
+  })
+
+  it('should report all namespaces when ignoreNamespaces is not specified', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app.ts')]: `
+        import { useTranslation } from 'react-i18next'
+        const { t } = useTranslation()
+        const { t: tShared } = useTranslation('shared')
+        t('local.key1')
+        tShared('shared.key1')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        local: { key1: 'Schlüssel 1' },
+      }),
+      [resolve(process.cwd(), 'locales/de/shared.json')]: JSON.stringify({
+        shared: { key1: 'Geteilt 1' },
+      }),
+    })
+
+    try {
+      await runStatus(mockConfig)
+    } catch (e) {
+      // Expected to throw when process.exit is called
+    }
+
+    // Should report 2 keys total (no filtering)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('🔑 Keys Found:         2'))
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('📚 Namespaces Found:   2'))
+  })
+
+  it('should correctly calculate overall completion when ignoring namespaces', async () => {
+    // Scenario: 3 namespaces, 2 ignored
+    // Only local namespace with 2 keys should be considered
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app.ts')]: `
+        import { useTranslation } from 'react-i18next'
+        const { t } = useTranslation()
+        const { t: tShared } = useTranslation('shared')
+        const { t: tLib } = useTranslation('lib')
+        t('local.key1')
+        t('local.key2')
+        tShared('shared.key1')
+        tShared('shared.key2')
+        tShared('shared.key3')
+        tLib('lib.key1')
+      `,
+      // All local keys translated in de
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        local: { key1: 'Schlüssel 1', key2: 'Schlüssel 2' },
+      }),
+      // All local keys translated in fr
+      [resolve(process.cwd(), 'locales/fr/translation.json')]: JSON.stringify({
+        local: { key1: 'Clé 1', key2: 'Clé 2' },
+      }),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared', 'lib'],
+      },
+    }
+
+    try {
+      await runStatus(config)
+    } catch (e) {
+      // Expected to throw when process.exit is called
+    }
+
+    // Should only count 2 keys from local namespace
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('🔑 Keys Found:         2'))
+    // Both de and fr should be 100% (2/2)
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('100% (2/2'))
+  })
+})

--- a/test/syncer.ignoreNamespaces.test.ts
+++ b/test/syncer.ignoreNamespaces.test.ts
@@ -1,0 +1,208 @@
+import { vol } from 'memfs'
+import { resolve } from 'path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { I18nextToolkitConfig } from '../src/index'
+import { runSyncer } from '../src/index'
+
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+vi.mock('glob', () => ({
+  glob: vi.fn(),
+}))
+
+const mockConfig: I18nextToolkitConfig = {
+  locales: ['en', 'de'],
+  extract: {
+    input: ['src/**/*.{ts,tsx}'],
+    output: 'locales/{{language}}/{{namespace}}.json',
+    defaultNS: 'translation',
+  },
+}
+
+describe('syncer: ignoreNamespaces', () => {
+  const enLocalPath = resolve(process.cwd(), 'locales/en/translation.json')
+  const deLocalPath = resolve(process.cwd(), 'locales/de/translation.json')
+  const enSharedPath = resolve(process.cwd(), 'locales/en/shared.json')
+  const deSharedPath = resolve(process.cwd(), 'locales/de/shared.json')
+  const enCommonPath = resolve(process.cwd(), 'locales/en/common.json')
+  const deCommonPath = resolve(process.cwd(), 'locales/de/common.json')
+
+  beforeEach(async () => {
+    vol.reset()
+    vi.clearAllMocks()
+
+    // Setup the glob mock to find the primary language files
+    const { glob } = await import('glob')
+    vi.mocked(glob).mockImplementation(async () => {
+      // Return all English locale files that exist in memfs
+      return Object.keys(vol.toJSON()).filter(p => p.includes('/locales/en/'))
+    })
+  })
+
+  it('should skip syncing ignored namespaces', async () => {
+    const enLocalTranslations = { local: { key: 'Local Value' } }
+    const enSharedTranslations = { shared: { key: 'Shared Value' } }
+
+    vol.fromJSON({
+      [enLocalPath]: JSON.stringify(enLocalTranslations),
+      [enSharedPath]: JSON.stringify(enSharedTranslations),
+      // de/translation.json is missing
+      // de/shared.json is missing
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared'],
+      },
+    }
+
+    await runSyncer(config)
+
+    // Local namespace should be synced
+    expect(vol.existsSync(deLocalPath)).toBe(true)
+    const deLocalContent = await vol.promises.readFile(deLocalPath, 'utf-8')
+    const deLocalJson = JSON.parse(deLocalContent as string)
+    expect(deLocalJson).toEqual({ local: { key: '' } })
+
+    // Shared namespace should NOT be synced (file should not be created)
+    expect(vol.existsSync(deSharedPath)).toBe(false)
+  })
+
+  it('should skip multiple ignored namespaces during sync', async () => {
+    const enLocalTranslations = { local: { key: 'Local Value' } }
+    const enSharedTranslations = { shared: { key: 'Shared Value' } }
+    const enCommonTranslations = { common: { key: 'Common Value' } }
+
+    vol.fromJSON({
+      [enLocalPath]: JSON.stringify(enLocalTranslations),
+      [enSharedPath]: JSON.stringify(enSharedTranslations),
+      [enCommonPath]: JSON.stringify(enCommonTranslations),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared', 'common'],
+      },
+    }
+
+    await runSyncer(config)
+
+    // Local namespace should be synced
+    expect(vol.existsSync(deLocalPath)).toBe(true)
+
+    // Shared and common namespaces should NOT be synced
+    expect(vol.existsSync(deSharedPath)).toBe(false)
+    expect(vol.existsSync(deCommonPath)).toBe(false)
+  })
+
+  it('should not modify existing ignored namespace files', async () => {
+    const enLocalTranslations = { local: { key: 'Local Value' } }
+    const enSharedTranslations = { shared: { key: 'Shared Value', newKey: 'New Value' } }
+    const existingDeSharedTranslations = { shared: { key: 'Geteilter Wert' } }
+
+    vol.fromJSON({
+      [enLocalPath]: JSON.stringify(enLocalTranslations),
+      [enSharedPath]: JSON.stringify(enSharedTranslations),
+      [deSharedPath]: JSON.stringify(existingDeSharedTranslations),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared'],
+      },
+    }
+
+    await runSyncer(config)
+
+    // Shared namespace file should remain unchanged (newKey should NOT be added)
+    const deSharedContent = await vol.promises.readFile(deSharedPath, 'utf-8')
+    const deSharedJson = JSON.parse(deSharedContent as string)
+    expect(deSharedJson).toEqual(existingDeSharedTranslations)
+  })
+
+  it('should sync all namespaces when ignoreNamespaces is empty', async () => {
+    const enLocalTranslations = { local: { key: 'Local Value' } }
+    const enSharedTranslations = { shared: { key: 'Shared Value' } }
+
+    vol.fromJSON({
+      [enLocalPath]: JSON.stringify(enLocalTranslations),
+      [enSharedPath]: JSON.stringify(enSharedTranslations),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: [],
+      },
+    }
+
+    await runSyncer(config)
+
+    // Both namespaces should be synced
+    expect(vol.existsSync(deLocalPath)).toBe(true)
+    expect(vol.existsSync(deSharedPath)).toBe(true)
+  })
+
+  it('should sync all namespaces when ignoreNamespaces is not specified', async () => {
+    const enLocalTranslations = { local: { key: 'Local Value' } }
+    const enSharedTranslations = { shared: { key: 'Shared Value' } }
+
+    vol.fromJSON({
+      [enLocalPath]: JSON.stringify(enLocalTranslations),
+      [enSharedPath]: JSON.stringify(enSharedTranslations),
+    })
+
+    await runSyncer(mockConfig)
+
+    // Both namespaces should be synced
+    expect(vol.existsSync(deLocalPath)).toBe(true)
+    expect(vol.existsSync(deSharedPath)).toBe(true)
+  })
+
+  it('should preserve existing translations in non-ignored namespaces while ignoring others', async () => {
+    const enLocalTranslations = {
+      local: { key1: 'Value 1', key2: 'Value 2' },
+    }
+    const enSharedTranslations = {
+      shared: { key1: 'Shared 1' },
+    }
+    const existingDeLocalTranslations = {
+      local: { key1: 'Wert 1' }, // key2 is missing
+    }
+
+    vol.fromJSON({
+      [enLocalPath]: JSON.stringify(enLocalTranslations),
+      [enSharedPath]: JSON.stringify(enSharedTranslations),
+      [deLocalPath]: JSON.stringify(existingDeLocalTranslations),
+    })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        ignoreNamespaces: ['shared'],
+      },
+    }
+
+    await runSyncer(config)
+
+    // Local namespace should be synced, preserving existing and adding missing
+    const deLocalContent = await vol.promises.readFile(deLocalPath, 'utf-8')
+    const deLocalJson = JSON.parse(deLocalContent as string)
+    expect(deLocalJson).toEqual({
+      local: { key1: 'Wert 1', key2: '' },
+    })
+
+    // Shared namespace should NOT be synced
+    expect(vol.existsSync(deSharedPath)).toBe(false)
+  })
+})


### PR DESCRIPTION
This commit adds a configuration option to ignore certain namespaces during extraction, status and sync operations.

This is useful for monorepos which might have a shared "common" namespace that is exposed to other projects in the monorepo.
Whenever those projects use those common translations, they are also extracted to their own locale files which in this case is unwanted behavior.

To use this, set the `ignoredNamespaces` option in the config file of the "downstream projects" to the ones that should be ignored (the namespaces coming in from the shared library).

This should cover an old feature request made here: https://github.com/i18next/i18next-parser/issues/160

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)