### PR TITLE
fix: extract ignoring keyPrefix in translation function call

### DIFF
--- a/src/extractor/parsers/call-expression-handler.ts
+++ b/src/extractor/parsers/call-expression-handler.ts
@@ -225,19 +225,28 @@ export class CallExpressionHandler {
 
       let finalKey = key
 
+      let keyPrefix: string | undefined
+      // Check for keyPrefix in call options before falling back to scope
+      if (options) {
+        const kpVal = getObjectPropValue(options, 'keyPrefix')
+        if (typeof kpVal === 'string') keyPrefix = kpVal
+      }
+      // Fall back to scope keyPrefix if not overridden in options
+      keyPrefix ||= scopeInfo?.keyPrefix
+
       // Apply keyPrefix AFTER namespace extraction
-      if (scopeInfo?.keyPrefix) {
+      if (keyPrefix) {
         const keySeparator = this.config.extract.keySeparator ?? '.'
 
         // Apply keyPrefix - handle case where keyPrefix already ends with separator
         if (keySeparator !== false) {
-          if (scopeInfo.keyPrefix.endsWith(keySeparator)) {
-            finalKey = `${scopeInfo.keyPrefix}${key}`
+          if (keyPrefix.endsWith(keySeparator)) {
+            finalKey = `${keyPrefix}${key}`
           } else {
-            finalKey = `${scopeInfo.keyPrefix}${keySeparator}${key}`
+            finalKey = `${keyPrefix}${keySeparator}${key}`
           }
         } else {
-          finalKey = `${scopeInfo.keyPrefix}${key}`
+          finalKey = `${keyPrefix}${key}`
         }
 
         // Validate keyPrefix combinations that create problematic keys
@@ -247,7 +256,7 @@ export class CallExpressionHandler {
           const hasEmptySegment = segments.some(segment => segment.trim() === '')
 
           if (hasEmptySegment) {
-            this.logger.warn(`Skipping key with empty segments: '${finalKey}' (keyPrefix: '${scopeInfo.keyPrefix}', key: '${key}')`)
+            this.logger.warn(`Skipping key with empty segments: '${finalKey}' (keyPrefix: '${keyPrefix}', key: '${key}')`)
             continue
           }
         }

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -201,6 +201,35 @@ describe('extractor: advanced t features', () => {
       })
     })
 
+    it('should handle keyPrefix override in t() options', async () => {
+      const sampleCode = `
+        const { t } = useTranslation('translation', { keyPrefix: 'very.deeply.nested' });
+        const defaultText = t('key');
+        const overrideText = t('key', { keyPrefix: 'overridden.prefix' }); // Should be 'overridden.prefix.key'
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/translation.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toEqual({
+        overridden: { // Create prefix for overridden keyPrefix
+          prefix: {
+            key: 'key',
+          },
+        },
+        very: { // Preserve default keyPrefix entries
+          deeply: {
+            nested: {
+              key: 'key',
+            },
+          },
+        },
+      })
+    })
+
     it('should handle aliased t functions from useTranslation', async () => {
       const sampleCode = `
         const { t: myTr } = useTranslation('ns1');


### PR DESCRIPTION
Fixes a bug where overriding a `keyPrefix` in a translation function call that has already been set in a scope has no effect. Take the following example:

```tsx
function App() {
  const { t } = useTranslation("translation", { keyPrefix: "app" });

  return (
    <>
      <div>
        <h1>{t("title", { ns: "override", keyPrefix: "" })}</h1>
      </div>
    </>
  );
}
```
 
Running the extract command on this file will result in the `override` namespace having the following structure:
 
```json
{
  "app": {
    "title": "value"
  }
}
```

instead of:
```json
{
  "title": "value"
}
```

The second example is resolved correctly by the `i18next` package at runtime. I can provide a working reproduction repo if needed.