### PR TITLE
feat(status): Add hideTranslated to show only untranslated keys in detail status view

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Displays a health check of your project's translation status. Can run without a 
 
 **Options:**
 - `--namespace <ns>, -n <ns>`: Filter the report by a specific namespace.
+- `--hide-translated`: Hide already translated keys in the detailed view, showing only missing translations.
 
 **Usage Examples:**
 
@@ -185,6 +186,12 @@ npx i18next-cli status --namespace common
 
 # Get a detailed report for the 'de' locale, showing only the 'common' namespace
 npx i18next-cli status de --namespace common
+
+# Show only the untranslated keys for the 'de' locale
+npx i18next-cli status de --hide-translated
+
+# Combine options to see only missing translations in a specific namespace
+npx i18next-cli status de --namespace common --hide-translated
 ```
 
 The detailed view provides a rich, at-a-glance summary for each namespace, followed by a list of every key and its translation status.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -98,6 +98,7 @@ program
   .command('status [locale]')
   .description('Display translation status. Provide a locale for a detailed key-by-key view.')
   .option('-n, --namespace <ns>', 'Filter the status report by a specific namespace')
+  .option('--hide-translated', 'Hide already translated keys in the detailed view')
   .action(async (locale, options) => {
     const cfgPath = program.opts().config
     let config = await loadConfig(cfgPath)
@@ -112,7 +113,7 @@ program
       console.log(styleText('green', 'Project structure detected successfully!'))
       config = detected as I18nextToolkitConfig
     }
-    await runStatus(config, { detail: locale, namespace: options.namespace })
+    await runStatus(config, { detail: locale, namespace: options.namespace, hideTranslated: !!options.hideTranslated })
   })
 
 program

--- a/src/status.ts
+++ b/src/status.ts
@@ -15,6 +15,8 @@ interface StatusOptions {
   detail?: string;
   /** Namespace to filter the report by */
   namespace?: string;
+  /** When true, only untranslated keys are shown in the detailed view */
+  hideTranslated?: boolean;
 }
 
 /**
@@ -270,7 +272,7 @@ async function generateStatusReport (config: I18nextToolkitConfig): Promise<Stat
  */
 async function displayStatusReport (report: StatusReport, config: I18nextToolkitConfig, options: StatusOptions) {
   if (options.detail) {
-    await displayDetailedLocaleReport(report, config, options.detail, options.namespace)
+    await displayDetailedLocaleReport(report, config, options.detail, options.namespace, options.hideTranslated)
   } else if (options.namespace) {
     await displayNamespaceSummaryReport(report, config, options.namespace)
   } else {
@@ -291,8 +293,9 @@ async function displayStatusReport (report: StatusReport, config: I18nextToolkit
  * @param config - The i18next toolkit configuration object
  * @param locale - The locale code to display details for
  * @param namespaceFilter - Optional namespace to filter the display
+ * @param hideTranslated - When true, only untranslated keys are shown
  */
-async function displayDetailedLocaleReport (report: StatusReport, config: I18nextToolkitConfig, locale: string, namespaceFilter?: string) {
+async function displayDetailedLocaleReport (report: StatusReport, config: I18nextToolkitConfig, locale: string, namespaceFilter?: string, hideTranslated?: boolean) {
   if (locale === config.extract.primaryLanguage) {
     console.log(styleText('yellow', `Locale "${locale}" is the primary language. All keys are considered present.`))
     return
@@ -323,7 +326,8 @@ async function displayDetailedLocaleReport (report: StatusReport, config: I18nex
     console.log(styleText(['cyan', 'bold'], `\nNamespace: ${ns}`))
     printProgressBar('Namespace Progress', nsData.translatedKeys, nsData.totalKeys)
 
-    nsData.keyDetails.forEach(({ key, isTranslated }) => {
+    const keysToDisplay = hideTranslated ? nsData.keyDetails.filter(({ isTranslated }) => !isTranslated) : nsData.keyDetails
+    keysToDisplay.forEach(({ key, isTranslated }) => {
       const icon = isTranslated ? styleText('green', '✓') : styleText('red', '✗')
       console.log(`  ${icon} ${key}`)
     })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -74,7 +74,20 @@ describe('CLI command parsing and dispatching', () => {
 
     expect(mockRunStatus).toHaveBeenCalledTimes(1)
     // Assert the actual two-argument call signature
-    expect(mockRunStatus).toHaveBeenCalledWith(config, { detail: 'en', namespace: undefined })
+    expect(mockRunStatus).toHaveBeenCalledWith(config, { detail: 'en', namespace: undefined, hideTranslated: false })
+  })
+
+  it('should parse the "status" command with --hide-translated and call runStatus', async () => {
+    vi.resetModules()
+    process.argv = ['node', 'cli.ts', 'status', 'en', '--hide-translated']
+    const config = { locales: ['en'], extract: {} }
+    mockLoadConfig.mockResolvedValue(config)
+
+    await import('../src/cli')
+
+    expect(mockRunStatus).toHaveBeenCalledTimes(1)
+    // Assert the actual two-argument call signature
+    expect(mockRunStatus).toHaveBeenCalledWith(config, { detail: 'en', namespace: undefined, hideTranslated: true })
   })
 
   it('should parse the "extract --ci" command and exit with error if files are updated', async () => {
@@ -286,7 +299,7 @@ describe('CLI command parsing and dispatching', () => {
 
     expect(mockRunStatus).toHaveBeenCalledTimes(1)
     expect(mockLoadConfig).toHaveBeenCalledWith('./custom/i18next.config.ts')
-    expect(mockRunStatus).toHaveBeenCalledWith(config, { detail: 'de', namespace: undefined })
+    expect(mockRunStatus).toHaveBeenCalledWith(config, { detail: 'de', namespace: undefined, hideTranslated: false })
   })
 
   it('should parse the "rename-key" command', async () => {

--- a/test/status.hide-translated.test.ts
+++ b/test/status.hide-translated.test.ts
@@ -1,0 +1,205 @@
+import { vol } from 'memfs'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { resolve } from 'path'
+import type { I18nextToolkitConfig } from '../src/index'
+
+// Mock filesystem used by extractor (both sync and promises layers)
+vi.mock('fs', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs
+})
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+
+// Mock glob so extractor only scans test files we create in memfs
+vi.mock('glob', () => ({ glob: vi.fn() }))
+
+// Import runStatus AFTER mocks so internal modules use the mocked fs/glob
+const { runStatus } = await import('../src/index')
+
+const mockConfig: I18nextToolkitConfig = {
+  locales: ['en', 'de', 'fr'],
+  extract: {
+    input: ['src/**/*.{ts,tsx}'],
+    output: 'locales/{{language}}/{{namespace}}.json',
+  },
+}
+
+describe('status (--hide-translated)', () => {
+  let consoleLogSpy: any
+
+  beforeEach(async () => {
+    vol.reset()
+    vi.clearAllMocks()
+    const { glob } = await import('glob')
+    vi.mocked(glob).mockImplementation(async (pattern: any, options?: any) => {
+      return Object.keys(vol.toJSON()).filter(p => p.includes('/src/'))
+    })
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('Process exit called')
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('should hide translated keys when hideTranslated is true', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app.ts')]: `
+        import { t } from 'i18next'
+        t('key.a')
+        t('key.b')
+        t('key.c')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        key: { a: 'Wert A', b: 'Wert B' },
+      }),
+    })
+
+    try {
+      await runStatus(mockConfig, { detail: 'de', hideTranslated: true })
+    } catch (e) {
+      // Expected to throw when process.exit is called
+    }
+
+    // key.c is NOT translated – it should be listed
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('key.c'))
+    // key.a and key.b ARE translated – they should NOT be listed
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringMatching(/[✓✗]\s+key\.a/))
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringMatching(/[✓✗]\s+key\.b/))
+  })
+
+  it('should still show all keys when hideTranslated is not set', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app2.ts')]: `
+        import { t } from 'i18next'
+        t('key.a')
+        t('key.b')
+        t('key.c')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        key: { a: 'Wert A', b: 'Wert B' },
+      }),
+    })
+
+    try {
+      await runStatus(mockConfig, { detail: 'de' })
+    } catch (e) {
+      // Expected
+    }
+
+    // All keys should be visible
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('key.a'))
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('key.b'))
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('key.c'))
+  })
+
+  it('should show progress bars even when hiding translated keys', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app3.ts')]: `
+        import { t } from 'i18next'
+        t('key.x')
+        t('key.y')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        key: { x: 'Wert X' },
+      }),
+    })
+
+    try {
+      await runStatus(mockConfig, { detail: 'de', hideTranslated: true })
+    } catch (e) {
+      // Expected
+    }
+
+    // Progress bars should still reflect the actual counts
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('50% (1/2)'))
+    // The untranslated key should be listed
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('key.y'))
+    // The translated key should NOT be listed
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringMatching(/[✓✗]\s+key\.x/))
+  })
+
+  it('should combine hideTranslated with namespace filtering', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app4.ts')]: `
+        import { t } from 'i18next'
+        t('app.title')
+        t('common:button.save')
+        t('common:button.cancel')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({}),
+      [resolve(process.cwd(), 'locales/de/common.json')]: JSON.stringify({
+        button: { save: 'Speichern' },
+      }),
+    })
+
+    try {
+      await runStatus(mockConfig, { detail: 'de', namespace: 'common', hideTranslated: true })
+    } catch (e) {
+      // Expected
+    }
+
+    // button.cancel is untranslated in the 'common' namespace – should be listed
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('button.cancel'))
+    // button.save IS translated – should NOT be listed
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringMatching(/[✓✗]\s+button\.save/))
+    // app.title from 'translation' namespace should not appear (namespace filter)
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringContaining('app.title'))
+  })
+
+  it('should show no keys when everything is translated and hideTranslated is true', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app5.ts')]: `
+        import { t } from 'i18next'
+        t('key.a')
+        t('key.b')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        key: { a: 'Wert A', b: 'Wert B' },
+      }),
+      [resolve(process.cwd(), 'locales/fr/translation.json')]: JSON.stringify({
+        key: { a: 'Valeur A', b: 'Valeur B' },
+      }),
+    })
+
+    await runStatus(mockConfig, { detail: 'de', hideTranslated: true })
+
+    // No key entries should be displayed at all
+    expect(consoleLogSpy).not.toHaveBeenCalledWith(expect.stringMatching(/[✓✗]\s+key\./))
+    // But the summary should still confirm all translations are present
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('All keys are translated'))
+  })
+
+  it('should only affect the detailed view, not the summary view', async () => {
+    vol.fromJSON({
+      [resolve(process.cwd(), 'src/app6.ts')]: `
+        import { t } from 'i18next'
+        t('key.a')
+        t('key.b')
+      `,
+      [resolve(process.cwd(), 'locales/de/translation.json')]: JSON.stringify({
+        key: { a: 'Wert A' },
+      }),
+      [resolve(process.cwd(), 'locales/fr/translation.json')]: JSON.stringify({
+        key: { a: 'Valeur A', b: 'Valeur B' },
+      }),
+    })
+
+    try {
+      // Summary view (no detail locale specified) should not be affected
+      await runStatus(mockConfig, { hideTranslated: true })
+    } catch (e) {
+      // Expected
+    }
+
+    // Summary view should show locale progress lines as usual
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('- de:'))
+    expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining('- fr:'))
+  })
+})


### PR DESCRIPTION
This commit adds a `--hide-translated` option to the `status` command.

I thought this could be helpful when trying to focus on those translations that are missing.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)