### PR TITLE
fix: bump minimatch from 10.2.2 to 10.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "inquirer": "13.2.5",
     "jiti": "2.6.1",
     "jsonc-parser": "3.3.1",
-    "minimatch": "10.2.2",
+    "minimatch": "10.2.4",
     "ora": "9.3.0",
     "react": "^19.2.4",
     "react-i18next": "^16.5.4"


### PR DESCRIPTION
## Summary

- Bumps `minimatch` from `10.2.2` to `10.2.4` to resolve two high-severity ReDoS vulnerabilities

Closes #196

## Test plan

- [x] All 683 existing tests pass with the updated dependency
- [x] `npm audit` reports 0 vulnerabilities after the change