### PR TITLE
fix: move react imports to devdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "eslint-plugin-import": "2.32.0",
     "memfs": "4.56.10",
     "neostandard": "0.12.2",
+    "react": "^19.2.4",
+    "react-i18next": "^16.5.4",
     "rollup-plugin-typescript2": "0.36.0",
     "typescript": "5.9.3",
     "unplugin-swc": "1.5.9",
@@ -80,8 +82,6 @@
     "jiti": "2.6.1",
     "jsonc-parser": "3.3.1",
     "minimatch": "10.2.2",
-    "ora": "9.3.0",
-    "react": "^19.2.4",
-    "react-i18next": "^16.5.4"
+    "ora": "9.3.0"
   }
 }


### PR DESCRIPTION
`react` and `react-i18next` are only being used in tests. This forces projects that aren't using these libraries, or are using different version of these libraris, to install them for no reason. Moving these dependencies to the `devDependencies` will address that issue.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
