### PR TITLE
Handle typed expressions in extractor

### DIFF
--- a/src/extractor/parsers/scope-manager.ts
+++ b/src/extractor/parsers/scope-manager.ts
@@ -1,4 +1,12 @@
-import type { VariableDeclarator, CallExpression, TemplateLiteral } from '@swc/core'
+import type {
+  Expression,
+  VariableDeclarator,
+  CallExpression,
+  TemplateLiteral,
+  TsAsExpression,
+  TsConstAssertion,
+  TsSatisfiesExpression
+} from '@swc/core'
 import type { ScopeInfo, UseTranslationHookConfig, I18nextToolkitConfig } from '../../types'
 import { getObjectPropValue } from './ast-utils'
 
@@ -12,6 +20,44 @@ export class ScopeManager {
 
   constructor (config: Omit<I18nextToolkitConfig, 'plugins'>) {
     this.config = config
+  }
+
+  /**
+   * Recursively unwraps TypeScript type assertion wrappers to reach the
+   * underlying expression node.
+   */
+  private static unwrapTsExpression (
+    node: TsConstAssertion | TsAsExpression | TsSatisfiesExpression | Expression
+  ): Expression {
+    if (!node) return node
+    switch (node.type) {
+      case 'TsConstAssertion':
+      case 'TsAsExpression':
+      case 'TsSatisfiesExpression':
+        return ScopeManager.unwrapTsExpression(node.expression)
+      default:
+        return node
+    }
+  }
+
+  /**
+   * Extracts a string value from a variable declarator's TypeScript type
+   * annotation when it is a literal string type (e.g., `const ns: 'users'`).
+   */
+  private static extractStringFromTypeAnnotation (node: VariableDeclarator): string | undefined {
+    if (!node?.id || node.id.type !== 'Identifier') return undefined
+    if ('typeAnnotation' in node.id) {
+      const rawTypeAnn = node.id.typeAnnotation
+      if (!rawTypeAnn) return undefined
+
+      const tsType = rawTypeAnn.typeAnnotation
+
+      if (tsType?.type === 'TsLiteralType' && tsType.literal?.type === 'StringLiteral') {
+        return tsType.literal.value
+      }
+    }
+
+    return undefined
   }
 
   /**
@@ -127,9 +173,19 @@ export class ScopeManager {
     const init = node.init
     if (!init) return
 
-    // Record simple const/let string initializers for later resolution
-    if (node.id.type === 'Identifier' && init.type === 'StringLiteral') {
-      this.simpleConstants.set(node.id.value, init.value)
+    // Record simple const/let string initializers for later resolution.
+    // Unwrap TS type assertion wrappers (as const, satisfies, as 'x') and fall
+    // back to the variable's type annotation when the init is not a string literal.
+    if (node.id.type === 'Identifier') {
+      const unwrapped = ScopeManager.unwrapTsExpression(init)
+      if (unwrapped?.type === 'StringLiteral') {
+        this.simpleConstants.set(node.id.value, unwrapped.value)
+      } else {
+        const fromType = ScopeManager.extractStringFromTypeAnnotation(node)
+        if (fromType !== undefined) {
+          this.simpleConstants.set(node.id.value, fromType)
+        }
+      }
       // continue processing; still may be a useTranslation/getFixedT call below
     }
 

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -272,6 +272,79 @@ describe('extractor: advanced t features', () => {
       })
     })
 
+    it('should handle namespace variable with `as const` assertion', async () => {
+      const sampleCode = `
+        const MY_NS = 'custom_namespace' as const
+
+        const { t } = useTranslation(MY_NS);
+        const text = t('key');
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/custom_namespace.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toEqual({
+        key: 'key',
+      })
+    })
+
+    it('should handle namespace variable with `satisfies` expression', async () => {
+      const sampleCode = `
+        const MY_NS = 'custom_namespace' satisfies string
+
+        const { t } = useTranslation(MY_NS);
+        const text = t('key');
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/custom_namespace.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toEqual({
+        key: 'key',
+      })
+    })
+
+    it('should handle namespace variable with `as` type assertion', async () => {
+      const sampleCode = `
+        const MY_NS = 'custom_namespace' as 'custom_namespace'
+
+        const { t } = useTranslation(MY_NS);
+        const text = t('key');
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/custom_namespace.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toEqual({
+        key: 'key',
+      })
+    })
+
+    it('should resolve namespace from type annotation when init is not a string literal', async () => {
+      const sampleCode = `
+        function getNamespace(): 'custom_namespace' { return 'custom_namespace' }
+        const MY_NS: 'custom_namespace' = getNamespace()
+
+        const { t } = useTranslation(MY_NS);
+        const text = t('key');
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/custom_namespace.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toEqual({
+        key: 'key',
+      })
+    })
+
     it('should handle aliased t functions from useTranslation', async () => {
       const sampleCode = `
         const { t: myTr } = useTranslation('ns1');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

Handle more cases than just string literal as argument for namespace to
translationFn. E.g. const assertions and strongly typed function calls.
This should cover more cases where users define namespaces as variable
assignments or dynamic function calls.



#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)


> Parts of this change was generated and implemented with the help of Claude Code/Opus 4.6. I have
> personally validated, modified and reviewed the changes before submitting this PR.
