### PR TITLE
Extractor: Handle object props as namespace

### DIFF
--- a/src/extractor/parsers/scope-manager.ts
+++ b/src/extractor/parsers/scope-manager.ts
@@ -1,5 +1,6 @@
 import type {
   Expression,
+  MemberExpression,
   VariableDeclarator,
   CallExpression,
   TemplateLiteral,
@@ -17,6 +18,9 @@ export class ScopeManager {
 
   // Track simple local constants with string literal values to resolve identifier args
   private simpleConstants: Map<string, string> = new Map()
+
+  // Track simple local constant objects with string literal property values
+  private simpleConstantObjects: Map<string, Record<string, string>> = new Map()
 
   constructor (config: Omit<I18nextToolkitConfig, 'plugins'>) {
     this.config = config
@@ -71,6 +75,7 @@ export class ScopeManager {
     this.scopeStack = []
     this.scope = new Map()
     this.simpleConstants.clear()
+    this.simpleConstantObjects.clear()
   }
 
   /**
@@ -159,6 +164,31 @@ export class ScopeManager {
   }
 
   /**
+   * Resolve a MemberExpression node (e.g., `ns.custom`) to its string value
+   * by looking up the object in `simpleConstantObjects`.
+   */
+  private resolveSimpleMemberExpression (node: MemberExpression): string | undefined {
+    if (node.object.type !== 'Identifier') {
+      return undefined
+    }
+
+    const map = this.simpleConstantObjects.get(node.object.value)
+    if (!map) {
+      return undefined
+    }
+
+    const prop = node.property
+    if (prop.type === 'Identifier') {
+      return map[prop.value]
+    }
+    if (prop.type === 'Computed' && prop.expression.type === 'StringLiteral') {
+      return map[prop.expression.value]
+    }
+
+    return undefined
+  }
+
+  /**
    * Handles variable declarations that might define translation functions.
    *
    * Processes two patterns:
@@ -180,6 +210,28 @@ export class ScopeManager {
       const unwrapped = ScopeManager.unwrapTsExpression(init)
       if (unwrapped?.type === 'StringLiteral') {
         this.simpleConstants.set(node.id.value, unwrapped.value)
+      } else if (unwrapped?.type === 'ObjectExpression' && Array.isArray(unwrapped.properties)) {
+        const map: Record<string, string> = {}
+        for (const p of unwrapped.properties) {
+          if (p.type !== 'KeyValueProperty') {
+            continue
+          }
+          const keyName = p.key.type === 'Identifier'
+            ? p.key.value
+            : p.key.type === 'StringLiteral'
+              ? p.key.value
+              : undefined
+          if (!keyName) {
+            continue
+          }
+          const val = ScopeManager.unwrapTsExpression(p.value)
+          if (val?.type === 'StringLiteral') {
+            map[keyName] = val.value
+          }
+        }
+        if (Object.keys(map).length > 0) {
+          this.simpleConstantObjects.set(node.id.value, map)
+        }
       } else {
         const fromType = ScopeManager.extractStringFromTypeAnnotation(node)
         if (fromType !== undefined) {
@@ -309,12 +361,16 @@ export class ScopeManager {
         if (nsNode?.type === 'StringLiteral') {
           defaultNs = nsNode.value
         } else if (nsNode?.type === 'Identifier') {
-          // ← FIX A: resolve const I18N_NS = 'users'
           defaultNs = this.resolveSimpleStringIdentifier(nsNode.value)
+        } else if (nsNode?.type === 'MemberExpression') {
+          defaultNs = this.resolveSimpleMemberExpression(nsNode)
         } else if (nsNode?.type === 'ArrayExpression') {
           const first = nsNode.elements[0]?.expression
-          if (first?.type === 'StringLiteral') defaultNs = first.value
-          else if (first?.type === 'Identifier') defaultNs = this.resolveSimpleStringIdentifier(first.value)
+          if (first?.type === 'StringLiteral') {
+            defaultNs = first.value
+          } else if (first?.type === 'Identifier') {
+            defaultNs = this.resolveSimpleStringIdentifier(first.value)
+          }
         }
       }
       kpArg = kpArgIndex === -1 ? undefined : callExpr.arguments?.[kpArgIndex]?.expression
@@ -387,12 +443,16 @@ export class ScopeManager {
         if (nsNode?.type === 'StringLiteral') {
           defaultNs = nsNode.value
         } else if (nsNode?.type === 'Identifier') {
-          // ← FIX A: resolve const I18N_NS = 'users'
           defaultNs = this.resolveSimpleStringIdentifier(nsNode.value)
+        } else if (nsNode?.type === 'MemberExpression') {
+          defaultNs = this.resolveSimpleMemberExpression(nsNode)
         } else if (nsNode?.type === 'ArrayExpression') {
           const first = nsNode.elements[0]?.expression
-          if (first?.type === 'StringLiteral') defaultNs = first.value
-          else if (first?.type === 'Identifier') defaultNs = this.resolveSimpleStringIdentifier(first.value)
+          if (first?.type === 'StringLiteral') {
+            defaultNs = first.value
+          } else if (first?.type === 'Identifier') {
+            defaultNs = this.resolveSimpleStringIdentifier(first.value)
+          }
         }
       }
       kpArg = kpArgIndex === -1 ? undefined : callExpr.arguments?.[kpArgIndex]?.expression

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -345,6 +345,24 @@ describe('extractor: advanced t features', () => {
       })
     })
 
+    it('should resolve namespace from type annotation in nested object', async () => {
+      const sampleCode = `
+        const ns = { custom: 'custom_namespace' as const } as const
+
+        const { t } = useTranslation(ns.custom);
+        const text = t('key');
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/custom_namespace.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toEqual({
+        key: 'key',
+      })
+    })
+
     it('should handle aliased t functions from useTranslation', async () => {
       const sampleCode = `
         const { t: myTr } = useTranslation('ns1');


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

I forgot to handle object properties in #204 😓 

This will handle those cases as well, which I found quite a few uses of in our own code at least,
where you define a const object of namespaces.

Hopefully this isn't too niche, but I do think that the more common patterns the extractor can cover
the better the cli is :)

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
