### PR TITLE
Resolve and safe constants cross-files

### DIFF
--- a/src/extractor/parsers/scope-manager.ts
+++ b/src/extractor/parsers/scope-manager.ts
@@ -22,6 +22,11 @@ export class ScopeManager {
   // Track simple local constant objects with string literal property values
   private simpleConstantObjects: Map<string, Record<string, string>> = new Map()
 
+  // Shared (cross-file) tables so that exported constants from one file can be
+  // resolved when imported in another. These are NOT cleared by reset().
+  private sharedConstants: Map<string, string> = new Map()
+  private sharedConstantObjects: Map<string, Record<string, string>> = new Map()
+
   constructor (config: Omit<I18nextToolkitConfig, 'plugins'>) {
     this.config = config
   }
@@ -160,7 +165,7 @@ export class ScopeManager {
    * Resolve simple identifier declared in-file to its string literal value, if known.
    */
   public resolveSimpleStringIdentifier (name: string): string | undefined {
-    return this.simpleConstants.get(name)
+    return this.simpleConstants.get(name) ?? this.sharedConstants.get(name)
   }
 
   /**
@@ -172,7 +177,7 @@ export class ScopeManager {
       return undefined
     }
 
-    const map = this.simpleConstantObjects.get(node.object.value)
+    const map = this.simpleConstantObjects.get(node.object.value) ?? this.sharedConstantObjects.get(node.object.value)
     if (!map) {
       return undefined
     }
@@ -210,6 +215,7 @@ export class ScopeManager {
       const unwrapped = ScopeManager.unwrapTsExpression(init)
       if (unwrapped?.type === 'StringLiteral') {
         this.simpleConstants.set(node.id.value, unwrapped.value)
+        this.sharedConstants.set(node.id.value, unwrapped.value)
       } else if (unwrapped?.type === 'ObjectExpression' && Array.isArray(unwrapped.properties)) {
         const map: Record<string, string> = {}
         for (const p of unwrapped.properties) {
@@ -231,11 +237,13 @@ export class ScopeManager {
         }
         if (Object.keys(map).length > 0) {
           this.simpleConstantObjects.set(node.id.value, map)
+          this.sharedConstantObjects.set(node.id.value, map)
         }
       } else {
         const fromType = ScopeManager.extractStringFromTypeAnnotation(node)
         if (fromType !== undefined) {
           this.simpleConstants.set(node.id.value, fromType)
+          this.sharedConstants.set(node.id.value, fromType)
         }
       }
       // continue processing; still may be a useTranslation/getFixedT call below

--- a/test/extractor.scope.test.ts
+++ b/test/extractor.scope.test.ts
@@ -114,4 +114,58 @@ describe('extractor: scope tests', () => {
       await fs.rm(tmp, { recursive: true, force: true })
     }
   })
+
+  it('should resolve imported string constants as useTranslation namespace', async () => {
+    const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'i18next-cli-test-'))
+    const originalCwd = process.cwd()
+    try {
+      const srcDir = path.join(tmp, 'src')
+      await fs.mkdir(srcDir, { recursive: true })
+
+      const constantsPath = path.join(srcDir, 'constants.ts')
+      const componentPath = path.join(srcDir, 'Component.tsx')
+
+      await fs.writeFile(
+        constantsPath,
+        `
+        export const I18N_NS = 'my-feature' as const
+        `
+      )
+
+      await fs.writeFile(
+        componentPath,
+        `
+        import { useTranslation } from 'react-i18next';
+        import { I18N_NS } from './constants';
+        export const Component = () => {
+          const { t } = useTranslation(I18N_NS);
+          return <div>{t('title')}</div>;
+        };
+        `
+      )
+
+      process.chdir(tmp)
+
+      const config = {
+        locales: ['en'],
+        extract: {
+          input: [constantsPath, componentPath],
+          output: 'locales/{{language}}/{{namespace}}.json',
+          functions: ['t'],
+          transComponents: [],
+          defaultNS: 'translation',
+        },
+      } as any
+
+      await runExtractor(config)
+
+      const nsPath = path.join(tmp, 'locales/en/my-feature.json')
+      const nsJson = JSON.parse(await fs.readFile(nsPath, 'utf-8'))
+
+      expect(nsJson).toHaveProperty('title')
+    } finally {
+      process.chdir(originalCwd)
+      await fs.rm(tmp, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
Another one from me here 😅 

When importing variables from other files, we need to keep the
declarations so the declarations are saved for future reference when
processing other files.

This fixes cases where declarations of variables passed to `useTranslation` are defined in other
files. The quirk here is that you need to ensure the files containing the declarations are parsed
before any other usages of those declarations.


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
