### PR TITLE
feat(types): support nested namespaces in type generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,8 @@ export default defineConfig({
   
   // TypeScript type generation
   types: {
-    input: ['locales/en/*.json'],
+    input: ['locales/en/*.json'], // or use '**/*.json' with basePath for nested namespaces
+    basePath: 'locales/en', // Optional: enables nested directory structures as namespaces
     output: 'src/types/i18next.d.ts',
     resourcesFile: 'src/types/resources.d.ts',
     enableSelector: true, // Enable type-safe key selection
@@ -1215,6 +1216,47 @@ export default {
   }
 } as const;
 ```
+
+### Nested Namespaces for Type Generation
+
+When generating TypeScript types, namespaces are derived from the filename only by default (e.g., `locales/en/dashboard/user.json` → namespace: `user`). If you organize translation files in nested directories and want the generated types to preserve that structure as part of the namespace, use the `basePath` option in your `types` configuration.
+
+Configuration (`i18next.config.ts`):
+
+```typescript
+export default defineConfig({
+  locales: ['en', 'de'],
+  extract: {
+    input: ['src/**/*.{ts,tsx}'],
+    output: 'public/locales/{{language}}/{{namespace}}.json',
+  },
+  types: {
+    input: 'public/locales/en/**/*.json',
+    basePath: 'public/locales/en',
+    output: 'src/types/i18next.d.ts',
+    resourcesFile: 'src/types/resources.d.ts',
+  }
+});
+```
+
+With this configuration:
+- `public/locales/en/common.json` → type namespace: `common`
+- `public/locales/en/dashboard/user.json` → type namespace: `dashboard/user`
+- `public/locales/en/dashboard/settings.json` → type namespace: `dashboard/settings`
+- `public/locales/en/features/auth/login.json` → type namespace: `features/auth/login`
+
+The `basePath` can include the `{{language}}` placeholder for flexibility:
+
+```typescript
+types: {
+  input: 'public/locales/en/**/*.json',
+  basePath: 'public/locales/{{language}}',
+  output: 'src/types/i18next.d.ts',
+  resourcesFile: 'src/types/resources.d.ts',
+}
+```
+
+This is useful for organizing translations into logical groups while maintaining type safety across your entire namespace hierarchy.
 
 ## Migration from i18next-parser
 

--- a/src/types-generator.ts
+++ b/src/types-generator.ts
@@ -4,7 +4,7 @@ import { glob } from 'glob'
 import { createSpinnerLike } from './utils/wrap-ora.js'
 import { styleText } from 'node:util'
 import { mkdir, readFile, writeFile, access } from 'node:fs/promises'
-import { basename, extname, resolve, dirname, join, relative } from 'node:path'
+import { basename, extname, resolve, dirname, join, relative, normalize } from 'node:path'
 import { transform } from '@swc/core'
 import type { I18nextToolkitConfig, Logger } from './types.js'
 import { getOutputPath } from './utils/file-utils.js'
@@ -61,13 +61,31 @@ async function loadFile (file: string) {
 }
 
 /**
+ * Extracts namespace from file path relative to base path.
+ * Preserves directory structure as namespace using forward slashes.
+ *
+ * @example
+ * getNamespaceFromPath('public/locales/en/dashboard/user.json', 'public/locales/en')
+ * // Returns: 'dashboard/user'
+ */
+function getNamespaceFromPath (filePath: string, basePath: string): string {
+  const normalized = normalize(filePath)
+  const normalizedBase = normalize(basePath)
+
+  let relativePath = relative(normalizedBase, normalized)
+  relativePath = relativePath.replace(extname(relativePath), '')
+
+  return relativePath.replace(/\\/g, '/')
+}
+
+/**
  * Generates TypeScript type definitions for i18next translations.
  *
  * This function:
  * 1. Reads translation files based on the input glob patterns
  * 2. Generates TypeScript interfaces using i18next-resources-for-ts
  * 3. Creates separate resources.d.ts and main i18next.d.ts files
- * 4. Handles namespace detection from filenames
+ * 4. Handles namespace detection from filenames. Supports nested namespaces when `basePath` is provided
  * 5. Supports type-safe selector API when enabled
  *
  * @param config - The i18next toolkit configuration object
@@ -108,14 +126,16 @@ export async function runTypesGenerator (
       return
     }
 
-    const resourceFiles = await glob(config.types?.input || [], {
-      cwd: process.cwd(),
-    })
+    const resourceFiles = await glob(config.types.input, { cwd: process.cwd() })
+    const basePath = config.types.basePath ? getOutputPath(config.types.basePath, config.extract.primaryLanguage) : undefined
 
     const resources: Resource[] = []
 
     for (const file of resourceFiles) {
-      const namespace = basename(file, extname(file))
+      const namespace = basePath
+        ? getNamespaceFromPath(file, basePath)
+        : basename(file, extname(file))
+
       const parsedContent = await loadFile(file)
 
       // If mergeNamespaces is used, a single file can contain multiple namespaces

--- a/src/types.ts
+++ b/src/types.ts
@@ -261,8 +261,32 @@ export interface I18nextToolkitConfig {
 
   /** Configuration options for TypeScript type generation */
   types?: {
-    /** Glob pattern(s) for translation files to generate types from */
+    /**
+     * Glob pattern(s) for translation files to generate types from.
+     *
+     * @example
+     * // Flat namespaces (filename only)
+     * 'public/locales/en/*.json'
+     *
+     * @example
+     * // Nested namespaces (requires basePath)
+     * input: 'public/locales/en/**\/*.json',
+     * basePath: 'public/locales/en'
+     */
     input: string | string[];
+
+    /**
+     * Base path for resolving namespaces from nested directory structures.
+     * When set, namespace is derived from the file's path relative to basePath.
+     *
+     * @example
+     * // Enable nested namespaces:
+     * input: 'public/locales/en/**\/*.json',
+     * basePath: 'public/locales/en'
+     * // 'public/locales/en/dashboard/user.json' → namespace: 'dashboard/user'
+     * // 'public/locales/en/common.json' → namespace: 'common'
+     */
+    basePath?: string;
 
     /** Output path for the main TypeScript definition file */
     output: string;

--- a/test/types-generator-nested-namespaces.test.ts
+++ b/test/types-generator-nested-namespaces.test.ts
@@ -1,0 +1,373 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { vol } from 'memfs'
+import { resolve } from 'node:path'
+import { runTypesGenerator } from '../src/types-generator'
+
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+
+vi.mock('glob', () => ({ glob: vi.fn() }))
+
+describe('types-generator with nested namespaces (basePath)', () => {
+  beforeEach(async () => {
+    vol.reset()
+    vi.clearAllMocks()
+    vi.spyOn(process, 'cwd').mockReturnValue('/project')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  describe('basePath support', () => {
+    it('should resolve nested namespaces when basePath is provided', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/public/locales/en/common.json',
+        '/project/public/locales/en/dashboard.json',
+        '/project/public/locales/en/dashboard/user.json',
+        '/project/public/locales/en/dashboard/settings.json',
+        '/project/public/locales/en/features/auth/login.json'
+      ])
+
+      vol.fromJSON({
+        '/project/public/locales/en/common.json': JSON.stringify({ key: 'value' }),
+        '/project/public/locales/en/dashboard.json': JSON.stringify({ title: 'Dashboard' }),
+        '/project/public/locales/en/dashboard/user.json': JSON.stringify({ name: 'User Name' }),
+        '/project/public/locales/en/dashboard/settings.json': JSON.stringify({ title: 'Settings' }),
+        '/project/public/locales/en/features/auth/login.json': JSON.stringify({ button: 'Login' })
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'public/locales/{{language}}/{{namespace}}.json',
+        },
+        types: {
+          input: 'public/locales/en/**/*.json',
+          basePath: 'public/locales/en',
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"common"')
+      expect(content).toContain('"dashboard"')
+      expect(content).toContain('"dashboard/user"')
+      expect(content).toContain('"dashboard/settings"')
+      expect(content).toContain('"features/auth/login"')
+    })
+
+    it('should support basePath with {{language}} placeholder', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/locales/en/translations/common.json',
+        '/project/locales/en/translations/admin/users.json'
+      ])
+
+      vol.fromJSON({
+        '/project/locales/en/translations/common.json': JSON.stringify({ key: 'value' }),
+        '/project/locales/en/translations/admin/users.json': JSON.stringify({ title: 'Users' })
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'locales/{{language}}/translations/{{namespace}}.json',
+        },
+        types: {
+          input: 'locales/en/translations/**/*.json',
+          basePath: 'locales/{{language}}/translations',
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"common"')
+      expect(content).toContain('"admin/users"')
+    })
+  })
+
+  describe('Backwards compatibility', () => {
+    it('should use filename-only namespaces when basePath is not provided', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/locales/en/common.json',
+        '/project/locales/en/user.json'
+      ])
+
+      vol.fromJSON({
+        '/project/locales/en/common.json': JSON.stringify({ key: 'value' }),
+        '/project/locales/en/user.json': JSON.stringify({ name: 'User' })
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'locales/en/*.json',
+        },
+        types: {
+          input: ['locales/en/*.json'], // No basePath
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"common"')
+      expect(content).toContain('"user"')
+      expect(content).toMatch(/"common":\s*\{/)
+      expect(content).toMatch(/"user":\s*\{/)
+      expect(content).not.toContain('"common/')
+      expect(content).not.toContain('"user/')
+      expect(content).not.toContain('"dashboard/')
+    })
+
+    it('should work with array of glob patterns (legacy behavior)', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/locales/en/common.json',
+        '/project/locales/en/errors.json'
+      ])
+
+      vol.fromJSON({
+        '/project/locales/en/common.json': JSON.stringify({ key: 'value' }),
+        '/project/locales/en/errors.json': JSON.stringify({ error: 'Error message' })
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'locales/en/*.json',
+        },
+        types: {
+          input: ['locales/en/common.json', 'locales/en/errors.json'],
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"common"')
+      expect(content).toContain('"errors"')
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('should handle deeply nested directory structures', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/locales/en/a/b/c/d/deep.json'
+      ])
+
+      vol.fromJSON({
+        '/project/locales/en/a/b/c/d/deep.json': JSON.stringify({ key: 'value' })
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'locales/{{language}}/{{namespace}}.json',
+        },
+        types: {
+          input: 'locales/en/**/*.json',
+          basePath: 'locales/en',
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"a/b/c/d/deep"')
+    })
+
+    it('should normalize paths to forward slashes for i18next', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/locales/en/dashboard/user.json'
+      ])
+
+      vol.fromJSON({
+        '/project/locales/en/dashboard/user.json': JSON.stringify({ name: 'User' })
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'locales/{{language}}/{{namespace}}.json',
+        },
+        types: {
+          input: 'locales/en/**/*.json',
+          basePath: '/project/locales/en',
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"dashboard/user"')
+      expect(content).not.toContain('\\')
+    })
+
+    it('should handle mixed flat and nested namespaces', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/locales/en/common.json',
+        '/project/locales/en/dashboard.json',
+        '/project/locales/en/dashboard/user.json',
+        '/project/locales/en/features/auth/login.json'
+      ])
+
+      vol.fromJSON({
+        '/project/locales/en/common.json': JSON.stringify({ key: 'value' }),
+        '/project/locales/en/dashboard.json': JSON.stringify({ title: 'Dashboard' }),
+        '/project/locales/en/dashboard/user.json': JSON.stringify({ name: 'User' }),
+        '/project/locales/en/features/auth/login.json': JSON.stringify({ button: 'Login' })
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'locales/{{language}}/{{namespace}}.json',
+        },
+        types: {
+          input: 'locales/en/**/*.json',
+          basePath: 'locales/en',
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"common"')
+      expect(content).toContain('"dashboard"')
+      expect(content).toContain('"dashboard/user"')
+      expect(content).toContain('"features/auth/login"')
+    })
+
+    it('should handle empty directories gracefully', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([])
+
+      vol.fromJSON({
+        '/project/locales/en/.gitkeep': ''
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          primaryLanguage: 'en',
+          output: 'locales/{{language}}/{{namespace}}.json',
+        },
+        types: {
+          input: 'locales/en/**/*.json',
+          basePath: 'locales/en',
+          output: 'src/types/i18next.d.ts',
+          resourcesFile: 'src/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('interface Resources')
+    })
+  })
+
+  describe('Integration with mergeNamespaces', () => {
+    it('should still support mergeNamespaces mode', async () => {
+      const { glob } = await import('glob') as any
+
+      ;(glob as any).mockResolvedValue([
+        '/project/localization/translations/en.json'
+      ])
+
+      vol.fromJSON({
+        '/project/localization/translations/en.json': JSON.stringify({
+          translation: {
+            addTerm: {
+              tabTitle: 'Add clue'
+            }
+          },
+          common: {
+            button: 'Click me'
+          }
+        }, null, 2),
+      })
+
+      const config: any = {
+        locales: ['en'],
+        extract: {
+          mergeNamespaces: true,
+          primaryLanguage: 'en',
+          output: 'localization/translations/{{language}}.json',
+        },
+        types: {
+          enableSelector: true,
+          input: 'localization/translations/en.json',
+          output: 'localization/types/i18next.d.ts',
+          resourcesFile: 'localization/types/resources.d.ts',
+        },
+      }
+
+      await runTypesGenerator(config)
+
+      const resourcesPath = resolve('/project', config.types.resourcesFile)
+      const content = await vol.promises.readFile(resourcesPath, 'utf8')
+
+      expect(content).toContain('"translation"')
+      expect(content).toContain('"common"')
+      expect(content).toContain('addTerm')
+      expect(content).toContain('button')
+    })
+  })
+})


### PR DESCRIPTION

Hey, thanks for maintaining this tool! This is my first contribution here, I'm more than happy to make changes and iterate on this feature!

---

This PR adds support for nested namespaces when generating types by providing a `types.basePath` in the config. 


### The issue
The existing implementation only looks at file name, not path, which caused a couple of issues. 

Assuming this config:
```ts
  extract: {
    input: 'src/**/*.{js,jsx,ts,tsx}',
    ignore: ['src/**/*.d.ts'],
    output: 'locales/{{language}}/{{namespace}}.json',
  },
  types: {
    input: ['locales/en/*.json'],
    output: 'src/types/i18next.d.ts',
  },
```

and these files:
```
locales/en/dashboard.json
locales/en/dashboard/user.json
locales/en/user.json
```

the resulting `Resources` type would look something like this:
```ts
interface Resource {
  "dashboard": { ... },
  "user": { ... },
}
```

1. The `dashboard/user` namespace is treated a just `"user"` and conflicts with the top-level "user" namespace. 
2. When using this in-app, you will get type errors when trying to use the nested namespace (`i18next.t('dashboard/user:some-key')`) even though it's valid.


### The solution
I added an optional `types.basePath` config value which, when provided, treats the rest of the file path after the base path as the namespace.

Given the same files, and this amended config:
```ts
types: {
  input: ['locales/en/*.json'],
  output: 'src/types/i18next.d.ts',
  basePath: 'locales/en'
},
```
The resulting Resources type retains proper namespaces:
```ts
interface Resource {
  "dashboard": { ... },
  "dashboard/user": { ... },
  "user": { ... },
}
```
This addresses the two issues.

When no `basePath` is provided, the existing functionality is preserved.


### Rationale
I went with this approach because i wanted to avoid breaking changes. I considered adding automatic detection of the "basePath" based on the glob pattern provided, or adding support for `{{namespace}}` in the input pattern, but both of these would be potentially breaking for anyone depending on the current functionality. The change in this PR is opt-in, so should be lower risk to adopt.


#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] only relevant documentation part is changed (make a diff before you submit the PR)
- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)