### PR TITLE
Infer function return types & CI failure details

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,8 @@ import { runStatus } from './status.js'
 import { runLocizeSync, runLocizeDownload, runLocizeMigrate } from './locize.js'
 import { runRenameKey } from './rename-key.js'
 import { runInstrumenter } from './instrumenter/index.js'
-import type { I18nextToolkitConfig } from './types.js'
+import { getNestedKeys, getNestedValue } from './utils/nested-object.js'
+import type { I18nextToolkitConfig, TranslationResult } from './types.js'
 
 const program = new Command()
 
@@ -47,7 +48,7 @@ program
       const runExtract = async () => {
         // --sync-all implies sync-primary behavior
         const syncPrimary = !!options.syncPrimary || !!options.syncAll
-        const { anyFileUpdated, hasErrors } = await runExtractor(config, {
+        const { anyFileUpdated, hasErrors, results } = await runExtractor(config, {
           isWatchMode: !!options.watch,
           isDryRun: !!options.dryRun,
           syncPrimaryWithDefaults: syncPrimary,
@@ -61,6 +62,7 @@ program
           process.exit(hasErrors ? 1 : 0)
         } else if (options.ci && anyFileUpdated) {
           console.error('❌ Some files were updated. This should not happen in CI mode.')
+          printCiDiff(results, config)
           process.exit(1)
         }
 
@@ -350,6 +352,73 @@ const expandGlobs = async (patterns: string | string[] = []) => {
   const arr = toArray(patterns)
   const sets = await Promise.all(arr.map(p => glob(p || '', { nodir: true })))
   return Array.from(new Set(sets.flat()))
+}
+
+function printCiDiff (results: TranslationResult[], config: I18nextToolkitConfig): void {
+  const rawSep = config.extract.keySeparator
+  const keySeparator: string | false = rawSep === false ? false : (rawSep ?? '.')
+
+  for (const result of results) {
+    if (!result.updated) continue
+
+    const existing = result.existingTranslations || {}
+    const next = result.newTranslations || {}
+    const oldKeys = new Set(getNestedKeys(existing, keySeparator))
+    const newKeys = new Set(getNestedKeys(next, keySeparator))
+
+    const added: string[] = []
+    const removed: string[] = []
+    const changed: string[] = []
+
+    for (const k of newKeys) {
+      if (!oldKeys.has(k)) {
+        added.push(k)
+      } else {
+        const oldVal = getNestedValue(existing, k, keySeparator)
+        const newVal = getNestedValue(next, k, keySeparator)
+        if (oldVal !== newVal) changed.push(k)
+      }
+    }
+    for (const k of oldKeys) {
+      if (!newKeys.has(k)) removed.push(k)
+    }
+
+    const nsLabel = result.namespace
+      ? ` [${result.locale}/${result.namespace}]`
+      : ` [${result.locale}]`
+    console.error(`\n  ${result.path}${nsLabel}`)
+
+    if (added.length === 0 && removed.length === 0 && changed.length === 0) {
+      console.error('    (no key differences — only formatting or ordering changes)')
+      continue
+    }
+
+    added.sort()
+    removed.sort()
+    changed.sort()
+
+    for (const k of added) {
+      const v = getNestedValue(next, k, keySeparator)
+      console.error(styleText('green', `    + ${k}: ${formatCiDiffValue(v)}`))
+    }
+    for (const k of removed) {
+      const v = getNestedValue(existing, k, keySeparator)
+      console.error(styleText('red', `    - ${k}: ${formatCiDiffValue(v)}`))
+    }
+    for (const k of changed) {
+      const oldV = getNestedValue(existing, k, keySeparator)
+      const newV = getNestedValue(next, k, keySeparator)
+      console.error(styleText('yellow', `    ~ ${k}: ${formatCiDiffValue(oldV)} → ${formatCiDiffValue(newV)}`))
+    }
+  }
+}
+
+function formatCiDiffValue (value: unknown): string {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
 }
 
 export { program }

--- a/src/extractor/core/ast-visitors.ts
+++ b/src/extractor/core/ast-visitors.ts
@@ -122,6 +122,16 @@ export class ASTVisitors {
         this.scopeManager.handleVariableDeclarator(node)
         this.expressionResolver.captureVariableDeclarator(node)
         break
+      case 'TSEnumDeclaration':
+      case 'TsEnumDeclaration':
+      case 'TsEnumDecl':
+        // Enums → ExpressionResolver.sharedEnumTable. Needed in pre-scan so
+        // that function bodies referencing enum members (e.g. `return
+        // OrganizationType.ROUTING`) can be resolved by the body-inference
+        // branch of captureFunctionDeclaration when we hit the function later
+        // in the same file.
+        this.expressionResolver.captureEnumDeclaration(node)
+        break
       case 'TsTypeAliasDeclaration':
       case 'TSTypeAliasDeclaration':
       case 'TsTypeAliasDecl':
@@ -130,7 +140,7 @@ export class ASTVisitors {
         break
       case 'FunctionDeclaration':
       case 'FnDecl':
-        // Return-type annotations for t(fn()) patterns
+        // Return-type annotations or inferred return values for t(fn()) patterns
         this.expressionResolver.captureFunctionDeclaration(node)
         break
     }

--- a/src/extractor/core/extractor.ts
+++ b/src/extractor/core/extractor.ts
@@ -53,7 +53,7 @@ export async function runExtractor (
     quiet?: boolean,
     logger?: Logger
   } = {}
-): Promise<{ anyFileUpdated: boolean; hasErrors: boolean }> {
+): Promise<{ anyFileUpdated: boolean; hasErrors: boolean; results: TranslationResult[] }> {
   config.extract.primaryLanguage ||= config.locales[0] || 'en'
   config.extract.secondaryLanguages ||= config.locales.filter((l: string) => l !== config?.extract?.primaryLanguage)
 
@@ -125,7 +125,7 @@ export async function runExtractor (
     // always show the funnel regardless of cooldown.
     if (anyFileUpdated && !options.isDryRun && !options.quiet) await printLocizeFunnel(options.logger, anyNewFile)
 
-    return { anyFileUpdated, hasErrors: fileErrors.length > 0 }
+    return { anyFileUpdated, hasErrors: fileErrors.length > 0, results }
   } catch (error) {
     spinner.fail(styleText('red', 'Extraction failed.'))
     // Re-throw or handle error

--- a/src/extractor/parsers/expression-resolver.ts
+++ b/src/extractor/parsers/expression-resolver.ts
@@ -24,6 +24,12 @@ export class ExpressionResolver {
   // Persists across resetFileSymbols() so exported type aliases are visible to importers.
   private sharedTypeAliasTable: Map<string, string[]> = new Map()
 
+  // Shared (cross-file) table for function return-value sets. Populated from
+  // both explicit return-type annotations and body-inferred return values so
+  // that `t(fn())` / `const x = fn(); t(\`...${x}...\`)` work across files.
+  // Persists across resetFileSymbols() just like the other shared tables.
+  private sharedFunctionReturnTable: Map<string, string[]> = new Map()
+
   // Temporary per-scope variable overrides, used to inject .map() / .forEach()
   // callback parameters while the callback body is being walked.
   private temporaryVariables: Map<string, string[]> = new Map()
@@ -183,15 +189,22 @@ export class ExpressionResolver {
       }
 
       // pattern 3 (arrow function variant):
-      // `const fn = (): 'a' | 'b' => ...` — capture the explicit return type annotation.
+      // `const fn = (): 'a' | 'b' => ...` — capture the explicit return type annotation,
+      // OR fall back to walking the body's return expressions / expression body
+      // when no annotation is present (mirrors TS's own return-type inference).
       if (unwrappedInit.type === 'ArrowFunctionExpression' || unwrappedInit.type === 'FunctionExpression') {
+        let returnVals: string[] = []
         const rawReturnType = unwrappedInit.returnType ?? unwrappedInit.typeAnnotation
         if (rawReturnType) {
+          // Explicit annotation — trust it even when it resolves to [].
           const tsType = rawReturnType.typeAnnotation ?? rawReturnType
-          const returnVals = this.resolvePossibleStringValuesFromType(tsType)
-          if (returnVals.length > 0) {
-            this.variableTable.set(name, returnVals)
-          }
+          returnVals = this.resolvePossibleStringValuesFromType(tsType)
+        } else {
+          returnVals = this.inferReturnValuesFromFunctionBody(unwrappedInit)
+        }
+        if (returnVals.length > 0) {
+          this.variableTable.set(name, returnVals)
+          this.sharedFunctionReturnTable.set(name, returnVals)
         }
       }
     } catch {
@@ -243,16 +256,87 @@ export class ExpressionResolver {
       // or directly in `.returnType` (FunctionExpression / ArrowFunctionExpression).
       const fn = node.function ?? node
       const rawReturnType = fn.returnType ?? fn.typeAnnotation
-      if (!rawReturnType) return
-      // Unwrap TsTypeAnnotation wrapper if present
-      const tsType = rawReturnType.typeAnnotation ?? rawReturnType
-      const vals = this.resolvePossibleStringValuesFromType(tsType)
+
+      let vals: string[] = []
+      if (rawReturnType) {
+        // Unwrap TsTypeAnnotation wrapper if present. Explicit annotations are
+        // authoritative: if the author declared the return type we trust it,
+        // even when it resolves to [] (e.g. plain `string`). Falling back to
+        // body inference in that case would invent keys the author deliberately
+        // opted out of.
+        const tsType = rawReturnType.typeAnnotation ?? rawReturnType
+        vals = this.resolvePossibleStringValuesFromType(tsType)
+      } else {
+        // No annotation — infer from body. Mirrors TS's own return-type
+        // inference for functions like:
+        //   function getCurrentAppType() {
+        //     if (...) return OrganizationType.ROUTING;
+        //     if (...) return OrganizationType.CONTRACTOR;
+        //   }
+        vals = this.inferReturnValuesFromFunctionBody(fn)
+      }
+
       if (vals.length > 0) {
         this.variableTable.set(name, vals)
+        this.sharedFunctionReturnTable.set(name, vals)
       }
     } catch {
       // noop
     }
+  }
+
+  /**
+   * Walk a function body's ReturnStatements and union the statically-resolvable
+   * string values of their argument expressions. Does NOT descend into nested
+   * function declarations (their returns belong to the inner function, not us).
+   *
+   * This is how we mirror TypeScript's implicit return-type inference for the
+   * purpose of extracting translation keys — we don't need exhaustiveness, just
+   * the set of string values any return statement could produce.
+   */
+  private inferReturnValuesFromFunctionBody (fn: any): string[] {
+    const body = fn?.body
+    if (!body) return []
+
+    const collected: string[] = []
+    const visit = (n: any): void => {
+      if (!n || typeof n !== 'object') return
+      // Don't descend into nested function bodies — their returns aren't ours.
+      if (
+        n !== body && (
+          n.type === 'FunctionDeclaration' ||
+          n.type === 'FunctionExpression' ||
+          n.type === 'ArrowFunctionExpression'
+        )
+      ) return
+
+      if (n.type === 'ReturnStatement' && n.argument) {
+        const vals = this.resolvePossibleStringValuesFromExpression(n.argument)
+        if (vals.length > 0) collected.push(...vals)
+      }
+
+      for (const key of Object.keys(n)) {
+        const child = (n as any)[key]
+        if (Array.isArray(child)) {
+          for (const item of child) {
+            if (item && typeof item === 'object') visit(item)
+          }
+        } else if (child && typeof child === 'object' && typeof child.type === 'string') {
+          visit(child)
+        }
+      }
+    }
+
+    // Arrow functions with an expression body (no BlockStatement) — `() => expr` —
+    // have their return expression directly as `body`.
+    if (body.type !== 'BlockStatement') {
+      const vals = this.resolvePossibleStringValuesFromExpression(body)
+      if (vals.length > 0) return Array.from(new Set(vals))
+      return []
+    }
+
+    visit(body)
+    return Array.from(new Set(collected))
   }
 
   /**
@@ -512,13 +596,18 @@ export class ExpressionResolver {
     }
 
     // pattern 3:
-    // `t(fn())` — resolve to the function's known return-type union when captured.
+    // `t(fn())` — resolve to the function's known return-value set (either
+    // from an explicit annotation or inferred from the function body). Check
+    // the per-file variable table first (same-file capture) and fall back to
+    // the shared cross-file table populated during pre-scan.
     if (expression.type === 'CallExpression') {
       try {
         const callee = (expression as any).callee
         if (callee?.type === 'Identifier') {
           const v = this.variableTable.get(callee.value)
           if (Array.isArray(v) && v.length > 0) return v
+          const sv = this.sharedFunctionReturnTable.get(callee.value)
+          if (sv && sv.length > 0) return sv
         }
       } catch {}
     }

--- a/test/extractor.finite.dynamic.keys.test.ts
+++ b/test/extractor.finite.dynamic.keys.test.ts
@@ -166,6 +166,58 @@ describe('extractor: finite dynamic key resolution (issue #210)', () => {
       const keys = Object.keys(translationFile?.newTranslations ?? {})
       expect(keys).toHaveLength(0)
     })
+
+    it('should infer return type from the body when no annotation is present', async () => {
+      // Mirrors the user's getCurrentAppType(): no explicit return type, body
+      // returns enum members via if/else. TS infers the union — extractor now
+      // does the same by walking the body's return statements.
+      const sampleCode = `
+        enum AppType { Routing = 'routing', Contractor = 'contractor' }
+        function getCurrentAppType() {
+          if (window.location.origin.includes('x')) return AppType.Routing;
+          return AppType.Contractor;
+        }
+        const type = getCurrentAppType();
+        t(\`app.\${type}.title\`);
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/translation.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toHaveProperty('app.routing.title')
+      expect(translationFile!.newTranslations).toHaveProperty('app.contractor.title')
+    })
+
+    it('should infer return type across files when the function is imported', async () => {
+      // Cross-file version of the previous case: getCurrentAppType lives in a
+      // separate module. The shared return-type table populated during
+      // pre-scan makes the inferred union visible to importers.
+      vol.fromJSON({
+        '/src/app-type.ts': `
+          export enum AppType { Routing = 'routing', Contractor = 'contractor' }
+          export function getCurrentAppType() {
+            if (window.location.origin.includes('x')) return AppType.Routing;
+            return AppType.Contractor;
+          }
+        `,
+        '/src/App.tsx': `
+          import { getCurrentAppType } from './app-type';
+          const type = getCurrentAppType();
+          t(\`app.\${type}.title\`);
+        `,
+      })
+      const { glob } = await import('glob')
+      ;(glob as any).mockResolvedValue(['/src/App.tsx', '/src/app-type.ts'])
+
+      const results = await extract(mockConfig)
+      const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/translation.json'))
+
+      expect(translationFile).toBeDefined()
+      expect(translationFile!.newTranslations).toHaveProperty('app.routing.title')
+      expect(translationFile!.newTranslations).toHaveProperty('app.contractor.title')
+    })
   })
 
   // ─── Pattern 4: t(map[dynamicKey]) where map is as const and key is a known union ─────────────

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -972,8 +972,12 @@ describe('extractor: advanced t features', () => {
     })
 
     it('should still return nothing for completely unresolvable dynamic bracket notation', async () => {
+      // The function has an explicit `: string` return type annotation — we
+      // respect explicit annotations authoritatively and do NOT fall back to
+      // body inference in that case, so the bracket access is genuinely
+      // unresolvable and no keys are extracted.
       const sampleCode = `
-        function getField() { return Math.random() > 0.5 ? "a" : "b"; }
+        function getField(): string { return Math.random() > 0.5 ? "a" : "b"; }
         t(($) => $.table.columns[getField()]);
       `
       vol.fromJSON({ '/src/App.tsx': sampleCode })
@@ -982,6 +986,29 @@ describe('extractor: advanced t features', () => {
 
       // No keys extracted means no translation file generated
       expect(file).toBeUndefined()
+    })
+
+    it('should resolve dynamic bracket notation from a function whose body returns a literal union (no annotation)', async () => {
+      // Without an explicit return annotation, TS infers getField's return type
+      // as `"a" | "b"`. The extractor now mirrors that inference and expands
+      // the selector bracket into both possibilities.
+      const sampleCode = `
+        function getField() { return Math.random() > 0.5 ? "a" : "b"; }
+        t(($) => $.table.columns[getField()]);
+      `
+      vol.fromJSON({ '/src/App.tsx': sampleCode })
+      const results = await extract(mockConfig)
+      const file = results.find(r => pathEndsWith(r.path, '/locales/en/translation.json'))
+
+      expect(file).toBeDefined()
+      expect(file!.newTranslations).toEqual({
+        table: {
+          columns: {
+            a: 'table.columns.a',
+            b: 'table.columns.b',
+          },
+        },
+      })
     })
   })
 


### PR DESCRIPTION


This PR does two things (can split if that's better):
- **Infer function return types from body for finite dynamic key resolution**
  Should extract keys and dynamic keys content that results from function calls with an easily
    inferable output type.

- **Print details of changes for extract --ci**
  I've had issues with the extraction being flaky with difficulty of reproducing locally. I suspect
  there is a race-condition in the extractor. This should help to see where the problem lies, as
  well as being generally useful to see what keys are missing when the failure is expected.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
