### PR TITLE
fix(extract): restrict scope-propagated t() matching to callees exactly matching configured functions (regression from #239)

### DIFF
--- a/src/extractor/parsers/call-expression-handler.ts
+++ b/src/extractor/parsers/call-expression-handler.ts
@@ -86,22 +86,6 @@ export class CallExpressionHandler {
     // The scope lookup will only work for simple identifiers, which is okay for this fix.
     let scopeInfo = getScopeInfo(functionName)
 
-    // For member expressions like `emailError.t`, also try the object part(s) as a
-    // fallback. This lets custom hooks that return an object with a `t` method
-    // (e.g. `const emailError = useTranslateKeyState('auth')`) propagate their
-    // namespace/keyPrefix to the inner `t` call.
-    if (!scopeInfo && functionName.includes('.')) {
-      const parts = functionName.split('.')
-      for (let i = parts.length - 1; i > 0; i--) {
-        const candidate = parts.slice(0, i).join('.')
-        const candidateScope = getScopeInfo(candidate)
-        if (candidateScope) {
-          scopeInfo = candidateScope
-          break
-        }
-      }
-    }
-
     const configuredFunctions = this.config.extract.functions || ['t', '*.t']
     let isFunctionToParse = scopeInfo !== undefined // A scoped variable (from useTranslation, etc.) is always parsed.
     if (!isFunctionToParse) {
@@ -122,6 +106,24 @@ export class CallExpressionHandler {
       }
     }
     if (!isFunctionToParse || node.arguments.length === 0) return
+
+    // For member expressions like `emailError.t`, also try the object part(s) as a
+    // fallback. This lets custom hooks that return an object with a `t` method
+    // (e.g. `const emailError = useTranslateKeyState('auth')`) propagate their
+    // namespace/keyPrefix to the inner `t` call. This runs AFTER the pattern
+    // check so an in-scope prefix cannot by itself promote an arbitrary method
+    // call (e.g. `i18n.language.substring(...)`) into a translation call.
+    if (!scopeInfo && functionName.includes('.')) {
+      const parts = functionName.split('.')
+      for (let i = parts.length - 1; i > 0; i--) {
+        const candidate = parts.slice(0, i).join('.')
+        const candidateScope = getScopeInfo(candidate)
+        if (candidateScope) {
+          scopeInfo = candidateScope
+          break
+        }
+      }
+    }
 
     const { keysToProcess, isSelectorAPI } = this.handleCallExpressionArgument(node, 0)
 

--- a/test/extractor.custom-hook.test.ts
+++ b/test/extractor.custom-hook.test.ts
@@ -191,6 +191,73 @@ describe('extractor: custom hook keyPrefix/namespace extraction', () => {
     })
   })
 
+  it('propagates namespace through a deeper member-expression chain (e.g. `wrapper.i18n.t(...)`)', async () => {
+    // When a custom hook returns a nested shape like `{ i18n: { t } }`, the
+    // scope attached to the outer variable must still propagate to the inner
+    // `t` call even though neither the full callee nor the immediate object
+    // is the scoped variable directly.
+    const sampleCode = `
+      const wrapper = useTranslateKeyState('auth')
+      wrapper.i18n.t('loginForm.input.email.required', 'Email is required')
+    `
+    vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        functions: ['t', '*.t'],
+        useTranslationNames: [
+          'useTranslation',
+          { name: 'useTranslateKeyState', nsArg: 0, keyPrefixArg: -1 },
+        ],
+      },
+    }
+
+    const results = await extract(config)
+    const authFile = results.find(r => pathEndsWith(r.path, '/locales/en/auth.json'))
+
+    expect(authFile).toBeDefined()
+    expect(authFile!.newTranslations).toEqual({
+      loginForm: {
+        input: {
+          email: {
+            required: 'Email is required',
+          },
+        },
+      },
+    })
+  })
+
+  it('does not treat arbitrary method calls on a scoped i18n object as translation calls', async () => {
+    // Only callees that match one of the configured `functions` patterns
+    // (here: `t` and `*.t`) are translation calls. A method call such as
+    // `i18n.language.substring(...)` or `i18n.languages.join(...)` on a
+    // variable that happens to be in scope (via `useTranslation()`
+    // destructuring) must not be extracted — its first literal argument is
+    // not a translation key.
+    const sampleCode = `
+      const { i18n } = useTranslation()
+      const lang = i18n.language.substring(0, 2)
+      const key = i18n.languages.join('|')
+    `
+    vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+    const config: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        functions: ['t', '*.t'],
+      },
+    }
+
+    const results = await extract(config)
+    const translationFile = results.find(r => pathEndsWith(r.path, '/locales/en/translation.json'))
+
+    // No t()/*.t() calls are present, so nothing should be extracted.
+    expect(translationFile?.newTranslations ?? {}).toEqual({})
+  })
+
   it('does not extract when keyPrefix is a template literal with expressions (current limitation)', async () => {
     const sampleCode = `
       const id = 'footer'


### PR DESCRIPTION
## Bug Description

I noticed that after an update I received weird artefacts in the extraction output like `"0": "0"` or `"|": "|"`.
After some investigation I pinpointed the origin of the issue to commit [`16c9b99`](https://github.com/i18next/i18next-cli/commit/16c9b99e0bbc3b67fd34fff45b84b84f2ea4765b) (released in v1.54.2), which added member-expression scope propagation as a response to issue [#239](https://github.com/i18next/i18next-cli/issues/239).

## Reproduction

```ts
// src/example.ts
import { useTranslation } from 'react-i18next'

export const useExample = () => {
  const { i18n } = useTranslation()
  const lang = i18n.language.substring(0, 2)      // leaked key "0"
  const key  = i18n.languages.join('|')           // leaked key "|"
  return { lang, key }
}
```

```ts
// i18next-cli.config.ts
export default defineConfig({
  locales: ['en'],
  extract: {
    input: ['src/**/*.{ts,tsx}'],
    output: 'locales/{{language}}/{{namespace}}.json',
    defaultNS: 'common',
  },
})
```

**Before (1.54.2+) — `locales/en/common.json`:**

```json
{ "0": "0", "|": "|" }
```

**After this PR:** empty (no `t()` / `*.t()` calls present).

## Root cause

In [`call-expression-handler.ts#L88-L106`](https://github.com/i18next/i18next-cli/blob/16c9b99/src/extractor/parsers/call-expression-handler.ts#L88-L106) (the block added by commit `16c9b99`), the fallback walks up the object parts of a member-expression callee (`i18n.language.substring` → `i18n.language` → `i18n`) to find scope info for propagating `defaultNs` / `keyPrefix` through calls like `obj.t(key)`. The fallback ran *before* the `functions` pattern check, and the next line was:

```ts
let isFunctionToParse = scopeInfo !== undefined
```

— so as soon as any prefix of the callee was in scope, the call got promoted to a translation call, bypassing the configured `functions` patterns entirely. Its first literal argument was then extracted as a key.

## Fix

Move the fallback lookup **after** the pattern check. A callee only becomes a translation call if it matches one of the configured `functions` patterns; the scope fallback then enriches that call with propagated `defaultNs` / `keyPrefix`. The scenario from issue #239 still works — `obj.t(key)` still matches `*.t`, still picks up scope — but arbitrary methods on scoped objects are no longer mis-extracted. `*.t` now consistently means "member expression whose final property is literally `t`".

## Tests

- New: asserts that `i18n.language.substring(0, 2)` and `i18n.languages.join('|')` produce no extracted keys with `functions: ['t', '*.t']`.
- New: deeper member-expression chain test (`wrapper.i18n.t(...)`) to lock in scope propagation through multi-segment object paths.
- The existing test for the issue #239 scenario (`emailError.t(...)` with `const emailError = useTranslateKeyState('auth')`) still passes — namespace propagation behaviour is preserved.
- Full suite: all 1021 tests pass, lint clean.

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

