### PR TITLE
feat(init): optionally scaffold an inlang project (--inlang)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ npx i18next-cli init
   also auto-detects `CI=true` and falls back to printing the URL on headless
   Linux (no `DISPLAY`/`WAYLAND_DISPLAY`), so this flag is rarely needed
   explicitly.
+- `--inlang`: Also scaffold an [inlang](https://inlang.com) project
+  (`project.inlang/settings.json`) so inlang tooling — the
+  [Sherlock](https://inlang.com/m/r7kp499g/app-inlang-ideExtension) VS Code
+  extension, the [Fink](https://fink.inlang.com) web editor for translators,
+  and the [Paraglide](https://inlang.com/m/gerre34r/library-inlang-paraglideJs)
+  compiler — works directly on your translation files. Skips the
+  corresponding wizard question.
 
 The wizard asks for the config file type, locales, source-file glob, output
 path, and finally **"Translation backend?"** with three options:
@@ -130,6 +137,23 @@ path, and finally **"Translation backend?"** with three options:
   works out of the box. The API key prompt can be left empty (read-only
   mode); add it later via a `LOCIZE_API_KEY` environment variable.
 - **Other / skip** — same as "Local files only" for the wizard's purposes.
+
+The wizard then offers to **set up inlang tooling** (default: no — or pass
+`--inlang` to skip the question). If accepted, it scaffolds a
+`project.inlang/settings.json` that points the
+[inlang i18next plugin](https://inlang.com/m/3i8bor92/plugin-inlang-i18next)
+at your existing translation files: `baseLocale`/`locales` come from your
+config, and `pathPattern` is derived from `extract.output` (the namespaced
+object form when your layout uses `{{namespace}}`, with namespaces discovered
+from the primary language's files; a plain pattern otherwise). It also adds
+the Sherlock extension to `.vscode/extensions.json` recommendations (merging
+comment-aware, never clobbering existing entries). Your i18next JSON files
+remain the single source of truth — inlang tools read and write them in
+place, so there is no second catalog to drift. An existing
+`project.inlang/settings.json` is never overwritten; re-running `init` is
+safe. Requires JSON resource files. The plugin is pinned to an exact verified
+version (`@inlang/plugin-i18next@6.2.0`) — bump the `modules` URL in
+`settings.json` to pick up newer plugin releases.
 
 ### `extract`
 Parses source files, extracts keys, and updates your JSON translation files.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,12 @@ place, so there is no second catalog to drift. An existing
 `project.inlang/settings.json` is never overwritten; re-running `init` is
 safe. Requires JSON resource files. The plugin is pinned to an exact verified
 version (`@inlang/plugin-i18next@6.2.0`) — bump the `modules` URL in
-`settings.json` to pick up newer plugin releases.
+`settings.json` to pick up newer plugin releases. Only `settings.json` is
+scaffolded by design: `project.inlang/` is the
+[unpacked (git-friendly)](https://inlang.com/docs/unpacked-project) project
+form, and inlang tools generate and manage its remaining files (`.gitignore`,
+`README.md`, `cache/`) on first use — so expect a few new files there after
+opening the project with Sherlock or Paraglide.
 
 ### `extract`
 Parses source files, extracts keys, and updates your JSON translation files.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -203,7 +203,8 @@ program
   .command('init')
   .description('Create a new i18next.config.ts/js file with an interactive setup wizard.')
   .option('--ci', 'Skip the browser launch when a backend (e.g. Locize) is selected. The signup URL is printed instead.')
-  .action((options) => runInit({ ci: !!options.ci }))
+  .option('--inlang', 'Also scaffold an inlang project (project.inlang/settings.json) so inlang tooling (Sherlock, Fink, Paraglide) works on the translation files. Skips the corresponding wizard question.')
+  .action((options) => runInit({ ci: !!options.ci, inlang: !!options.inlang }))
 
 program
   .command('lint')

--- a/src/init.ts
+++ b/src/init.ts
@@ -3,6 +3,7 @@ import { writeFile, readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { detectConfig } from './heuristic-config.js'
 import { openBrowser, promptLocizeCredentials } from './utils/locize-onboarding.js'
+import { scaffoldInlangProject } from './utils/inlang-scaffold.js'
 
 const LOCIZE_SIGNUP_URL = 'https://www.locize.app/register?from=i18next_cli__init-wizard'
 
@@ -93,7 +94,7 @@ async function isTypeScriptProject (): Promise<boolean> {
  * // - i18next.config.js (JavaScript ESM/CommonJS)
  * ```
  */
-export async function runInit (options: { ci?: boolean } = {}) {
+export async function runInit (options: { ci?: boolean, inlang?: boolean } = {}) {
   console.log('Welcome to the i18next-cli setup wizard!')
   console.log('Scanning your project for a recommended configuration...')
 
@@ -156,6 +157,14 @@ export async function runInit (options: { ci?: boolean } = {}) {
         { name: 'Other / skip', value: 'other' },
       ],
       default: 'local',
+    },
+    {
+      type: 'confirm',
+      name: 'inlang',
+      message: 'Also set up inlang tooling (Sherlock VS Code extension, Fink editor, Paraglide) on these translation files?',
+      default: false,
+      // Skip the question when already requested via the --inlang flag.
+      when: () => !options.inlang,
     },
   ])
 
@@ -253,6 +262,14 @@ module.exports = ${toJs(configObject)}`
   await writeFile(outputPath, fileContent.trim())
 
   console.log(`✅ Configuration file created at: ${outputPath}`)
+
+  if (options.inlang || answers.inlang) {
+    await scaffoldInlangProject({
+      locales: answers.locales,
+      primaryLanguage: answers.locales[0],
+      output: answers.output,
+    })
+  }
 
   if (locizeConfig) {
     console.log('\nNext steps for Locize:')

--- a/src/utils/inlang-scaffold.ts
+++ b/src/utils/inlang-scaffold.ts
@@ -52,8 +52,10 @@ export async function scaffoldInlangProject (options: InlangScaffoldOptions): Pr
     return
   }
 
-  // {{lng}} is a supported alias for {{language}}
-  const template = output.replace(/\{\{lng\}\}/g, '{{language}}')
+  // Normalize Windows separators (heuristic-detected templates may be built
+  // with path.join) — settings.json patterns must be POSIX for portability.
+  // {{lng}} is a supported alias for {{language}}.
+  const template = output.replace(/\\/g, '/').replace(/\{\{lng\}\}/g, '{{language}}')
 
   if (!template.endsWith('.json')) {
     console.log('⚠️  Skipping inlang setup: the inlang i18next plugin supports JSON resource files only, but extract.output points to non-JSON files.')
@@ -93,8 +95,9 @@ export async function scaffoldInlangProject (options: InlangScaffoldOptions): Pr
 
 /**
  * Converts an i18next-cli output template into an inlang `pathPattern`:
- * `{{language}}` becomes `{locale}` and the path is made explicitly relative,
- * as required by the plugin's settings schema.
+ * `{{language}}` becomes `{locale}`, and relative paths are prefixed with
+ * `./` as required by the plugin's settings schema (which also permits
+ * `../`-relative and absolute paths, so those pass through unchanged).
  */
 function toInlangPattern (template: string): string {
   const pattern = template.replace(/\{\{language\}\}/g, '{locale}')

--- a/src/utils/inlang-scaffold.ts
+++ b/src/utils/inlang-scaffold.ts
@@ -1,0 +1,214 @@
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises'
+import { resolve, dirname } from 'node:path'
+import { parse, modify, applyEdits, type ParseError } from 'jsonc-parser'
+
+/**
+ * The plugin that teaches inlang tools (Sherlock, Fink, Paraglide) to read and
+ * write i18next JSON resource files directly.
+ *
+ * Pinned to an exact version on purpose: 6.2.0 is the first release with
+ * verified round-trip support for plurals, context, `_zero` and ordinal keys,
+ * and jsDelivr serves floating range URLs (`@6`) from edge caches that can
+ * lag releases by days. Bump deliberately when newer verified versions ship.
+ */
+const INLANG_PLUGIN_MODULE = 'https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.2.0/dist/index.js'
+
+/** VS Code marketplace id of the inlang Sherlock extension. */
+const SHERLOCK_EXTENSION_ID = 'inlang.vs-code-extension'
+
+export interface InlangScaffoldOptions {
+  /** All project locales (the first one is used as `baseLocale` unless `primaryLanguage` is set). */
+  locales: string[]
+  /** The base/source locale. Defaults to the first entry of `locales`. */
+  primaryLanguage?: string
+  /** The `extract.output` template, e.g. `public/locales/{{language}}/{{namespace}}.json`. */
+  output: string | ((language: string, namespace?: string) => string)
+  /** Default namespace used as fallback when no resource files exist yet (default: 'translation'). */
+  defaultNS?: string | false
+}
+
+/**
+ * Scaffolds an inlang project (`project.inlang/settings.json`) next to the
+ * i18next configuration so that inlang tooling (Sherlock VS Code extension,
+ * Fink editor, Paraglide compiler) operates on the EXISTING i18next JSON
+ * files. The i18next files remain the single source of truth — the scaffold
+ * is just the adapter.
+ *
+ * Behavior:
+ * - Derives `plugin.inlang.i18next.pathPattern` from the `extract.output`
+ *   template: the namespaced object form when the template contains a
+ *   `{{namespace}}` placeholder (namespaces are discovered from the files of
+ *   the primary language), the plain string form otherwise.
+ * - Never overwrites an existing `project.inlang/settings.json`.
+ * - Adds the Sherlock extension to `.vscode/extensions.json` recommendations
+ *   (creating or comment-preservingly merging the file).
+ */
+export async function scaffoldInlangProject (options: InlangScaffoldOptions): Promise<void> {
+  const { locales, output } = options
+  const baseLocale = options.primaryLanguage || locales[0] || 'en'
+
+  if (typeof output !== 'string') {
+    console.log('⚠️  Skipping inlang setup: extract.output is a function, so the file layout cannot be derived automatically. Create project.inlang/settings.json manually (see https://inlang.com/m/3i8bor92/plugin-inlang-i18next).')
+    return
+  }
+
+  // {{lng}} is a supported alias for {{language}}
+  const template = output.replace(/\{\{lng\}\}/g, '{{language}}')
+
+  if (!template.endsWith('.json')) {
+    console.log('⚠️  Skipping inlang setup: the inlang i18next plugin supports JSON resource files only, but extract.output points to non-JSON files.')
+    return
+  }
+
+  const settingsDir = resolve(process.cwd(), 'project.inlang')
+  const settingsPath = resolve(settingsDir, 'settings.json')
+
+  if (await fileExists(settingsPath)) {
+    console.log('ℹ️  project.inlang/settings.json already exists — leaving it untouched.')
+  } else {
+    const pathPattern = template.includes('{{namespace}}')
+      ? await deriveNamespacedPathPattern(template, baseLocale, options.defaultNS)
+      : toInlangPattern(template)
+
+    const settings = {
+      $schema: 'https://inlang.com/schema/project-settings',
+      baseLocale,
+      locales,
+      modules: [INLANG_PLUGIN_MODULE],
+      'plugin.inlang.i18next': { pathPattern },
+    }
+
+    await mkdir(settingsDir, { recursive: true })
+    await writeFile(settingsPath, JSON.stringify(settings, null, 2) + '\n')
+
+    console.log(`✅ inlang project created at: ${settingsPath}`)
+    console.log('   Your i18next JSON files stay the single source of truth — inlang tools read and write them directly.')
+    console.log(`   • Sherlock (VS Code): install the recommended "${SHERLOCK_EXTENSION_ID}" extension`)
+    console.log('   • Fink (web editor for translators): https://fink.inlang.com')
+    console.log('   • Paraglide (compiled i18n): npx @inlang/paraglide-js compile --project ./project.inlang')
+  }
+
+  await recommendSherlockExtension()
+}
+
+/**
+ * Converts an i18next-cli output template into an inlang `pathPattern`:
+ * `{{language}}` becomes `{locale}` and the path is made explicitly relative,
+ * as required by the plugin's settings schema.
+ */
+function toInlangPattern (template: string): string {
+  const pattern = template.replace(/\{\{language\}\}/g, '{locale}')
+  if (pattern.startsWith('./') || pattern.startsWith('../') || pattern.startsWith('/')) {
+    return pattern
+  }
+  return `./${pattern}`
+}
+
+/**
+ * Builds the namespaced (object) form of `pathPattern` by discovering the
+ * project's namespaces from the existing resource files of the primary
+ * language. Falls back to the default namespace when no files exist yet
+ * (e.g. `init` ran before the first `extract`).
+ */
+async function deriveNamespacedPathPattern (
+  template: string,
+  baseLocale: string,
+  defaultNS?: string | false
+): Promise<Record<string, string>> {
+  const namespaces = await discoverNamespaces(template, baseLocale)
+  if (namespaces.length === 0) {
+    namespaces.push(typeof defaultNS === 'string' ? defaultNS : 'translation')
+  }
+
+  const pathPattern: Record<string, string> = {}
+  for (const ns of namespaces.sort()) {
+    pathPattern[ns] = toInlangPattern(template.replace(/\{\{namespace\}\}/g, ns))
+  }
+  return pathPattern
+}
+
+/**
+ * Discovers namespace names by listing the directory entries that match the
+ * `{{namespace}}` segment of the output template, resolved for the primary
+ * language. Works for namespaces in the file name
+ * (`locales/en/{{namespace}}.json`) as well as in a directory segment
+ * (`locales/{{namespace}}/en.json`).
+ */
+async function discoverNamespaces (template: string, baseLocale: string): Promise<string[]> {
+  const resolved = template.replace(/\{\{language\}\}/g, baseLocale)
+  const segments = resolved.split('/')
+  const nsIndex = segments.findIndex(segment => segment.includes('{{namespace}}'))
+  if (nsIndex === -1) return []
+
+  const baseDir = resolve(process.cwd(), segments.slice(0, nsIndex).join('/'))
+  const [prefix, suffix = ''] = segments[nsIndex].split('{{namespace}}')
+
+  try {
+    const entries = await readdir(baseDir)
+    return entries
+      .filter(entry =>
+        entry.startsWith(prefix) &&
+        entry.endsWith(suffix) &&
+        entry.length > prefix.length + suffix.length)
+      .map(entry => entry.slice(prefix.length, entry.length - suffix.length))
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Adds the Sherlock VS Code extension to `.vscode/extensions.json`
+ * recommendations. Creates the file when missing; otherwise merges into the
+ * existing one while preserving comments and formatting (JSONC-aware). Bails
+ * gracefully — with a notice, never an error — when the existing file cannot
+ * be parsed.
+ */
+async function recommendSherlockExtension (): Promise<void> {
+  const extensionsPath = resolve(process.cwd(), '.vscode', 'extensions.json')
+
+  let text: string | undefined
+  try {
+    text = await readFile(extensionsPath, 'utf-8')
+  } catch {
+    // File doesn't exist yet — create it.
+  }
+
+  if (text === undefined || text.trim() === '') {
+    await mkdir(dirname(extensionsPath), { recursive: true })
+    await writeFile(extensionsPath, JSON.stringify({ recommendations: [SHERLOCK_EXTENSION_ID] }, null, 2) + '\n')
+    console.log('✅ Added the Sherlock extension to .vscode/extensions.json recommendations.')
+    return
+  }
+
+  const errors: ParseError[] = []
+  const current = parse(text, errors, { allowTrailingComma: true })
+  if (errors.length > 0 || typeof current !== 'object' || current === null || Array.isArray(current)) {
+    console.log('⚠️  Could not parse .vscode/extensions.json — please add "inlang.vs-code-extension" to its recommendations manually.')
+    return
+  }
+
+  const recommendations: unknown[] = Array.isArray(current.recommendations) ? current.recommendations : []
+  const alreadyRecommended = recommendations.some(
+    entry => typeof entry === 'string' && entry.toLowerCase() === SHERLOCK_EXTENSION_ID
+  )
+  if (alreadyRecommended) return
+
+  const formattingOptions = { insertSpaces: true, tabSize: 2, eol: '\n' }
+  const edits = Array.isArray(current.recommendations)
+    // Append to the existing array (preserves comments and formatting).
+    ? modify(text, ['recommendations', recommendations.length], SHERLOCK_EXTENSION_ID, { isArrayInsertion: true, formattingOptions })
+    // No recommendations key yet — add one.
+    : modify(text, ['recommendations'], [SHERLOCK_EXTENSION_ID], { formattingOptions })
+
+  await writeFile(extensionsPath, applyEdits(text, edits))
+  console.log('✅ Added the Sherlock extension to .vscode/extensions.json recommendations.')
+}
+
+async function fileExists (path: string): Promise<boolean> {
+  try {
+    await readFile(path)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/test/init.inlang.test.ts
+++ b/test/init.inlang.test.ts
@@ -1,0 +1,230 @@
+import { vol } from 'memfs'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { runInit } from '../src/init'
+import inquirer from 'inquirer'
+import { resolve } from 'path'
+
+// Mocks
+vi.mock('fs/promises', async () => {
+  const memfs = await vi.importActual<typeof import('memfs')>('memfs')
+  return memfs.fs.promises
+})
+vi.mock('inquirer')
+vi.mock('execa', () => ({
+  execa: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+}))
+vi.mock('../src/heuristic-config', () => ({
+  detectConfig: vi.fn(),
+}))
+
+const SHERLOCK = 'inlang.vs-code-extension'
+
+const baseAnswers = {
+  fileType: 'TypeScript (i18next.config.ts)',
+  locales: ['en', 'de'],
+  input: 'src/**/*.tsx',
+  output: 'public/locales/{{language}}/{{namespace}}.json',
+  backend: 'local',
+}
+
+async function readJson (path: string): Promise<any> {
+  return JSON.parse(await vol.promises.readFile(resolve('/', path), 'utf-8') as string)
+}
+
+describe('init --inlang (inlang project scaffold)', () => {
+  beforeEach(() => {
+    vol.reset()
+    vi.clearAllMocks()
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(process, 'cwd').mockReturnValue('/')
+    vi.stubEnv('CI', '')
+    vi.stubEnv('WSL_DISTRO_NAME', '')
+    vi.stubEnv('DISPLAY', ':0')
+    vi.stubEnv('WAYLAND_DISPLAY', '')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('scaffolds project.inlang with a namespaced pathPattern derived from existing files', async () => {
+    vol.fromJSON({
+      '/public/locales/en/common.json': '{}',
+      '/public/locales/en/app.json': '{}',
+      '/public/locales/de/common.json': '{}',
+    })
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const settings = await readJson('project.inlang/settings.json')
+    expect(settings).toStrictEqual({
+      $schema: 'https://inlang.com/schema/project-settings',
+      baseLocale: 'en',
+      locales: ['en', 'de'],
+      modules: ['https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.2.0/dist/index.js'],
+      'plugin.inlang.i18next': {
+        pathPattern: {
+          app: './public/locales/{locale}/app.json',
+          common: './public/locales/{locale}/common.json',
+        },
+      },
+    })
+  })
+
+  it('does not scaffold when the wizard question is declined (default)', async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: false })
+
+    await runInit()
+
+    expect(vol.existsSync(resolve('/', 'project.inlang/settings.json'))).toBe(false)
+    expect(vol.existsSync(resolve('/', '.vscode/extensions.json'))).toBe(false)
+  })
+
+  it('asks the wizard question by default and skips it when --inlang is passed', async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers })
+
+    await runInit()
+    const withoutFlag: any = vi.mocked(inquirer.prompt).mock.calls[0][0]
+    const question = (withoutFlag as any[]).find(q => q.name === 'inlang')
+    expect(question).toBeDefined()
+    expect(question.default).toBe(false)
+    expect(question.when()).toBe(true)
+
+    vi.mocked(inquirer.prompt).mockClear()
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers })
+
+    await runInit({ inlang: true })
+    const withFlag: any = vi.mocked(inquirer.prompt).mock.calls[0][0]
+    const skippedQuestion = (withFlag as any[]).find(q => q.name === 'inlang')
+    expect(skippedQuestion.when()).toBe(false)
+    // The flag scaffolds even though the wizard answer is absent.
+    expect(vol.existsSync(resolve('/', 'project.inlang/settings.json'))).toBe(true)
+  })
+
+  it('derives a string pathPattern for single-file outputs (no {{namespace}})', async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      ...baseAnswers,
+      output: 'locales/{{language}}.json',
+      inlang: true,
+    })
+
+    await runInit()
+
+    const settings = await readJson('project.inlang/settings.json')
+    expect(settings['plugin.inlang.i18next'].pathPattern).toBe('./locales/{locale}.json')
+  })
+
+  it('supports the {{lng}} placeholder alias', async () => {
+    vol.fromJSON({ '/locales/en/main.json': '{}' })
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      ...baseAnswers,
+      output: 'locales/{{lng}}/{{namespace}}.json',
+      inlang: true,
+    })
+
+    await runInit()
+
+    const settings = await readJson('project.inlang/settings.json')
+    expect(settings['plugin.inlang.i18next'].pathPattern).toStrictEqual({
+      main: './locales/{locale}/main.json',
+    })
+  })
+
+  it('falls back to the "translation" namespace when no resource files exist yet', async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const settings = await readJson('project.inlang/settings.json')
+    expect(settings['plugin.inlang.i18next'].pathPattern).toStrictEqual({
+      translation: './public/locales/{locale}/translation.json',
+    })
+  })
+
+  it('never overwrites an existing project.inlang/settings.json', async () => {
+    const existing = '{\n  "custom": true\n}\n'
+    vol.fromJSON({ '/project.inlang/settings.json': existing })
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const content = await vol.promises.readFile(resolve('/', 'project.inlang/settings.json'), 'utf-8')
+    expect(content).toBe(existing)
+    // The extension recommendation is still applied (idempotent re-runs stay clean).
+    const extensions = await readJson('.vscode/extensions.json')
+    expect(extensions.recommendations).toContain(SHERLOCK)
+  })
+
+  it('creates .vscode/extensions.json with the Sherlock recommendation', async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const extensions = await readJson('.vscode/extensions.json')
+    expect(extensions).toStrictEqual({ recommendations: [SHERLOCK] })
+  })
+
+  it('merges into an existing extensions.json, preserving comments and entries', async () => {
+    vol.fromJSON({
+      '/.vscode/extensions.json': '{\n  // team picks\n  "recommendations": [\n    "dbaeumer.vscode-eslint"\n  ]\n}\n',
+    })
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const content = await vol.promises.readFile(resolve('/', '.vscode/extensions.json'), 'utf-8') as string
+    expect(content).toContain('// team picks')
+    expect(content).toContain('dbaeumer.vscode-eslint')
+    expect(content).toContain(SHERLOCK)
+  })
+
+  it('adds a recommendations array to an extensions.json that lacks one', async () => {
+    vol.fromJSON({
+      '/.vscode/extensions.json': '{\n  "unwantedRecommendations": []\n}\n',
+    })
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const content = await vol.promises.readFile(resolve('/', '.vscode/extensions.json'), 'utf-8') as string
+    expect(content).toContain('unwantedRecommendations')
+    expect(content).toContain(SHERLOCK)
+  })
+
+  it('does not duplicate an already-present Sherlock recommendation', async () => {
+    const existing = `{\n  "recommendations": [\n    "${SHERLOCK}"\n  ]\n}\n`
+    vol.fromJSON({ '/.vscode/extensions.json': existing })
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const content = await vol.promises.readFile(resolve('/', '.vscode/extensions.json'), 'utf-8')
+    expect(content).toBe(existing)
+  })
+
+  it('leaves an unparseable extensions.json untouched and still completes', async () => {
+    const broken = '{ this is not json'
+    vol.fromJSON({ '/.vscode/extensions.json': broken })
+    vi.mocked(inquirer.prompt).mockResolvedValue({ ...baseAnswers, inlang: true })
+
+    await runInit()
+
+    const content = await vol.promises.readFile(resolve('/', '.vscode/extensions.json'), 'utf-8')
+    expect(content).toBe(broken)
+    expect(vol.existsSync(resolve('/', 'project.inlang/settings.json'))).toBe(true)
+  })
+
+  it('skips the scaffold with a notice for non-JSON outputs', async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      ...baseAnswers,
+      output: 'locales/{{language}}/{{namespace}}.yaml',
+      inlang: true,
+    })
+
+    await runInit()
+
+    expect(vol.existsSync(resolve('/', 'project.inlang/settings.json'))).toBe(false)
+  })
+})

--- a/test/init.inlang.test.ts
+++ b/test/init.inlang.test.ts
@@ -116,6 +116,26 @@ describe('init --inlang (inlang project scaffold)', () => {
     expect(settings['plugin.inlang.i18next'].pathPattern).toBe('./locales/{locale}.json')
   })
 
+  it('normalizes Windows path separators in detected output templates', async () => {
+    vol.fromJSON({
+      '/public/locales/en/common.json': '{}',
+      '/public/locales/en/app.json': '{}',
+    })
+    vi.mocked(inquirer.prompt).mockResolvedValue({
+      ...baseAnswers,
+      output: 'public\\locales\\{{language}}\\{{namespace}}.json',
+      inlang: true,
+    })
+
+    await runInit()
+
+    const settings = await readJson('project.inlang/settings.json')
+    expect(settings['plugin.inlang.i18next'].pathPattern).toStrictEqual({
+      app: './public/locales/{locale}/app.json',
+      common: './public/locales/{locale}/common.json',
+    })
+  })
+
   it('supports the {{lng}} placeholder alias', async () => {
     vol.fromJSON({ '/locales/en/main.json': '{}' })
     vi.mocked(inquirer.prompt).mockResolvedValue({


### PR DESCRIPTION
Lets i18next users put inlang tooling (Sherlock, Fink, Paraglide) on their **existing** translation files — the i18next JSON stays the single source of truth, the scaffold is just the adapter. Design as discussed with @samuelstroschein on Discord (Jun 11); the underlying interop fixes landed on the inlang side in a couple of hours and are released (`@inlang/plugin-i18next` 6.2.0, `@inlang/sdk` 2.10.0, `@inlang/paraglide-js` 2.19.0), verified end-to-end against the published packages.

## What it does

- New wizard step (default: **no**) after the backend question, plus non-interactive `init --inlang` (skips the question).
- Emits `project.inlang/settings.json`: `baseLocale`/`locales` from the config; `plugin.inlang.i18next.pathPattern` derived from `extract.output` — the namespaced object form when the layout uses `{{namespace}}` (namespace names discovered from the primary language's existing files, `translation` fallback on fresh projects), the string form for single-file layouts; `{{lng}}` alias supported; non-JSON layouts skip with a notice.
- Adds `inlang.vs-code-extension` to `.vscode/extensions.json` recommendations — created when missing, otherwise merged comment-preservingly via jsonc-parser `modify`/`applyEdits`; unparseable files are left untouched with a notice; no duplicates.
- Idempotent: an existing `project.inlang/settings.json` is never overwritten; re-running `init` stays clean.

## Why the plugin version is pinned exactly

The scaffold pins `https://cdn.jsdelivr.net/npm/@inlang/plugin-i18next@6.2.0/dist/index.js`. A smoke test of the emitted settings against the released toolchain caught that jsDelivr's floating range alias (`@6`) still served **6.1.3** from edge caches after the 6.2.0 release — i.e. range/`@latest` URLs deliver the pre-fix plugin (context bugs, un-savable projects) until the caches turn, while exact-version URLs get 6.2.0 immediately. The README documents bumping the pin deliberately.

## Tests

12 new tests in `test/init.inlang.test.ts`: wizard yes/no/flag behavior, pathPattern derivation (namespaced, single-file, `{{lng}}` alias, fresh-project fallback), never-overwrite, and the extensions.json create/merge/comment-preservation/duplicate/broken-file matrix. Full suite: 1166 passing.

cc @samuelstroschein — this is the `init` scaffold we discussed; feedback very welcome.
