### PR TITLE
Fix: ConsoleLogger.warn/error swallow their second argument

### DIFF
--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -24,13 +24,20 @@ export class ConsoleLogger implements Logger {
    * Logs a warning message to the console.
    *
    * @param message - The warning message to log
+   * @param more - Optional additional detail (e.g. a caught error). Forwarded to
+   *   `console.warn` so thrown errors surfaced by plugin hooks are not swallowed.
    */
-  warn (message: string): void { console.warn(message) }
+  warn (message: string, more?: unknown): void {
+    if (more === undefined) { console.warn(message) } else { console.warn(message, more) }
+  }
 
   /**
    * Logs an error message to the console.
    *
    * @param message - The error message to log
+   * @param more - Optional additional detail (e.g. a caught error).
    */
-  error (message: string): void { console.error(message) }
+  error (message: string | unknown, more?: unknown): void {
+    if (more === undefined) { console.error(message) } else { console.error(message, more) }
+  }
 }

--- a/test/console-logger.test.ts
+++ b/test/console-logger.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { ConsoleLogger } from '../src/utils/logger'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('ConsoleLogger', () => {
+  it('forwards the optional second argument to console.warn (so plugin errors are not swallowed)', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const logger = new ConsoleLogger()
+    const err = new Error('boom')
+
+    logger.warn('Plugin my-plugin failed:', err)
+
+    expect(spy).toHaveBeenCalledWith('Plugin my-plugin failed:', err)
+  })
+
+  it('does not pass a second argument to console.warn when none is provided', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const logger = new ConsoleLogger()
+
+    logger.warn('just a message')
+
+    expect(spy).toHaveBeenCalledWith('just a message')
+    expect(spy.mock.calls[0]).toHaveLength(1)
+  })
+
+  it('forwards the optional second argument to console.error', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const logger = new ConsoleLogger()
+    const err = new Error('boom')
+
+    logger.error('something failed:', err)
+
+    expect(spy).toHaveBeenCalledWith('something failed:', err)
+  })
+})


### PR DESCRIPTION
The Logger interface declares warn(message, more?), and ~10 call sites pass a caught error as that second arg (e.g. logger.warn(\Plugin ${plugin.name} extractContextFromExpression
  failed:`, err)inkey-finder.ts). But ConsoleLogger.warnonly forwarded the message toconsole.warn, so plugin-hook errors printed as a bare ... failed:with no detail (see screenshot). 
  This forwards the optional second arg on bothwarnanderror`, leaving single-arg output unchanged.

  Adds test/console-logger.test.ts. Note: 2 pre-existing failures in test/status.test.ts are unrelated (fail on main too).



#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)

#### Checklist (for documentation change)

- [x] motivation/reason is provided
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)