### PR TITLE
fix: change prompt type from 'list' to 'select' in runInstrumenter function

### DIFF
--- a/src/instrumenter/core/instrumenter.ts
+++ b/src/instrumenter/core/instrumenter.ts
@@ -113,7 +113,7 @@ export async function runInstrumenter (
           for (const candidate of candidates) {
             const { action } = await inquirer.prompt([
               {
-                type: 'list',
+                type: 'select',
                 name: 'action',
                 message: `Translate: "${candidate.content}" (${candidate.line}:${candidate.column})?`,
                 choices: [


### PR DESCRIPTION
`runInstrumenter()` used a deprecated and now removed inquirer type called `list`.
The prompt type `list` was deprecated and replaced by `select` a few versions ago in inquirer and was removed with version [13.0.0](https://github.com/SBoudrias/Inquirer.js/releases/tag/inquirer@13.0.0).

#### Checklist

- [x] only relevant code is changed (make a diff before you submit the PR)
- [x] run tests `npm run test`
- [x] tests are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/i18next/.github/blob/master/CONTRIBUTING.md)
