### PR TITLE
fix extractor support for shorthand namespace options

### DIFF
--- a/src/extractor/parsers/ast-utils.ts
+++ b/src/extractor/parsers/ast-utils.ts
@@ -376,5 +376,14 @@ export function getObjectPropValue (object: ObjectExpression, propName: string, 
     if (val.type === 'NumericLiteral') return val.value
     return '' // Indicate presence for other types
   }
+
+  // SWC represents shorthand options such as `{ ns }` as bare Identifiers.
+  const shorthand = object.properties.find(
+    (p): p is Identifier => p.type === 'Identifier' && p.value === propName
+  )
+  if (shorthand) {
+    return identifierResolver ? identifierResolver(shorthand.value) : ''
+  }
+
   return undefined
 }

--- a/test/extractor.t.test.ts
+++ b/test/extractor.t.test.ts
@@ -85,6 +85,32 @@ describe('extractor: advanced t features', () => {
     })
   })
 
+  it('should resolve a shorthand "ns" option in t()', async () => {
+    const sampleCode = `
+      const ns = 'common'
+      t('button.save', { ns, defaultValue: 'Save' })
+    `
+    vol.fromJSON({ '/src/App.tsx': sampleCode })
+
+    const configWithNsOptions: I18nextToolkitConfig = {
+      ...mockConfig,
+      extract: {
+        ...mockConfig.extract,
+        nsSeparator: false,
+      },
+    }
+
+    const results = await extract(configWithNsOptions)
+    const commonFile = results.find(r => pathEndsWith(r.path, '/locales/en/common.json'))
+
+    expect(commonFile).toBeDefined()
+    expect(commonFile!.newTranslations).toEqual({
+      button: {
+        save: 'Save',
+      },
+    })
+  })
+
   describe('in react-i18next', () => {
     it('should detect the namespace from useTranslation("ns1")', async () => {
       const sampleCode = `


### PR DESCRIPTION
The extractor resolves explicit options such as `{ ns: NS }`, but misses shorthand `{ ns }` because SWC represents the shorthand as a bare Identifier rather than a KeyValueProperty.

Handle that AST form with the existing identifier resolver and add a regression test proving the key is written to the resolved namespace.

Tests:
- `npm test`
- `npx vitest run test/extractor.t.test.ts`
- mutation check: the new test fails without the production fix